### PR TITLE
Moof and meta sub boxes, rebased correctly

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,8 @@ add_library(lovok_internal
         boxes/moof_sub_boxes.cpp
         boxes/moof_sub_boxes.h
         boxes/traf_sub_boxes.cpp
-        boxes/traf_sub_boxes.h)
+        boxes/traf_sub_boxes.h
+        boxes/meta_sub_boxes.cpp
+        boxes/meta_sub_boxes.h)
 
 target_link_libraries(lovok_internal file_io)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,6 +47,8 @@ add_library(lovok_internal
         boxes/mvex_sub_boxes.cpp
         boxes/mvex_sub_boxes.h
         boxes/moof_sub_boxes.cpp
-        boxes/moof_sub_boxes.h)
+        boxes/moof_sub_boxes.h
+        boxes/traf_sub_boxes.cpp
+        boxes/traf_sub_boxes.h)
 
 target_link_libraries(lovok_internal file_io)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,6 +51,10 @@ add_library(lovok_internal
         boxes/traf_sub_boxes.cpp
         boxes/traf_sub_boxes.h
         boxes/meta_sub_boxes.cpp
-        boxes/meta_sub_boxes.h)
+        boxes/meta_sub_boxes.h
+        boxes/ipro_sub_boxes.cpp
+        boxes/ipro_sub_boxes.h
+        boxes/sinf_sub_boxes.cpp
+        boxes/sinf_sub_boxes.h)
 
 target_link_libraries(lovok_internal file_io)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,6 +55,10 @@ add_library(lovok_internal
         boxes/ipro_sub_boxes.cpp
         boxes/ipro_sub_boxes.h
         boxes/sinf_sub_boxes.cpp
-        boxes/sinf_sub_boxes.h)
+        boxes/sinf_sub_boxes.h
+        boxes/fiin_sub_boxes.cpp
+        boxes/fiin_sub_boxes.h
+        boxes/paen_sub_boxes.cpp
+        boxes/paen_sub_boxes.h)
 
 target_link_libraries(lovok_internal file_io)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,6 +45,8 @@ add_library(lovok_internal
         boxes/stbl_sub_boxes.cpp
         boxes/stbl_sub_boxes.h
         boxes/mvex_sub_boxes.cpp
-        boxes/mvex_sub_boxes.h)
+        boxes/mvex_sub_boxes.h
+        boxes/moof_sub_boxes.cpp
+        boxes/moof_sub_boxes.h)
 
 target_link_libraries(lovok_internal file_io)

--- a/src/boxes/fiin_sub_boxes.cpp
+++ b/src/boxes/fiin_sub_boxes.cpp
@@ -1,0 +1,33 @@
+#include "../lovok_handle_internal.h"
+#include "fiin_sub_boxes.h"
+#include "paen_sub_boxes.h"
+
+LovokStatusCode ParsePaen(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    byteOffset += 8;
+    length -= 8;
+    LovokStatusCode parseResults = ParseBoxes(fileWrapper,
+                                              length,
+                                              byteOffset,
+                                              [&fileWrapper] (const Box &header, uint64_t byteOffset) -> LovokStatusCode {
+          LovokStatusCode result = SUCCESS;
+          if (!strcmp(header.name, "fire")) {
+              result = ParseFire(fileWrapper, header.size, byteOffset);
+          } else if (!strcmp(header.name, "fpar")) {
+              result = ParseFpar(fileWrapper, header.size, byteOffset);
+          } else if (!strcmp(header.name, "fecr")) {
+              result = ParseFecr(fileWrapper, header.size, byteOffset);
+          }
+          return result;
+      });
+    return parseResults;
+}
+
+LovokStatusCode ParseSegr(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    return SUCCESS;
+    //todo if this is involved in an exploit
+}
+
+LovokStatusCode ParseGitn(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    return SUCCESS;
+    //todo if this is involved in an exploit
+}

--- a/src/boxes/fiin_sub_boxes.h
+++ b/src/boxes/fiin_sub_boxes.h
@@ -1,0 +1,16 @@
+#include "box.h"
+#include "../lovok_handle_internal.h"
+#include "../include/lovok.h"
+#include "io/file_io.h"
+#include <functional>
+
+#ifndef LOVOK_FIIN_SUB_BOXES_H
+#define LOVOK_FIIN_SUB_BOXES_H
+
+LovokStatusCode ParsePaen(FileWrapper *, uint64_t, uint64_t);
+
+LovokStatusCode ParseSegr(FileWrapper *, uint64_t, uint64_t);
+
+LovokStatusCode ParseGitn(FileWrapper *, uint64_t, uint64_t);
+
+#endif //LOVOK_FIIN_SUB_BOXES_H

--- a/src/boxes/file_level_boxes.cpp
+++ b/src/boxes/file_level_boxes.cpp
@@ -17,7 +17,7 @@ LovokStatusCode ParseMoov(FileWrapper *fileWrapper, uint64_t length, uint64_t by
         } else if (!strcmp(header.name, "mvhd")) {
             result = ParseMvhd(fileWrapper, header.size, byteOffset);
         } else if (!strcmp(header.name, "meta")) {
-            result = ParseMeta(fileWrapper, header.size, byteOffset);
+            result = ParseMoovMeta(fileWrapper, header.size, byteOffset);
         } else if (!strcmp(header.name, "mvex")) {
             result = ParseMvex(fileWrapper, header.size, byteOffset);
         }
@@ -37,7 +37,7 @@ LovokStatusCode ParseMoof(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           if (!strcmp(header.name, "mfhd")) {
               result = ParseMfhd(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "meta")) {
-              result = ParseMeta(fileWrapper, header.size, byteOffset);
+              result = ParseMoofMeta(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "traf")) {
               result = ParseTraf(fileWrapper, header.size, byteOffset);
           }

--- a/src/boxes/file_level_boxes.cpp
+++ b/src/boxes/file_level_boxes.cpp
@@ -3,6 +3,7 @@
 #include "../lovok_handle_internal.h"
 #include "moov_sub_boxes.h"
 #include "moof_sub_boxes.h"
+#include "meta_sub_boxes.h"
 
 LovokStatusCode ParseMoov(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
     byteOffset += 8;
@@ -40,6 +41,42 @@ LovokStatusCode ParseMoof(FileWrapper *fileWrapper, uint64_t length, uint64_t by
               result = ParseMoofMeta(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "traf")) {
               result = ParseTraf(fileWrapper, header.size, byteOffset);
+          }
+          return result;
+      });
+    return parseResults;
+}
+
+LovokStatusCode ParseMeta(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    byteOffset += 8;
+    length -= 8;
+    LovokStatusCode parseResults = ParseBoxes(fileWrapper,
+                                              length,
+                                              byteOffset,
+                                              [&fileWrapper] (const Box &header, uint64_t byteOffset) -> LovokStatusCode {
+          LovokStatusCode result = SUCCESS;
+          if (!strcmp(header.name, "hdlr")) {
+              result = ParseHdlr(fileWrapper, header.size, byteOffset);
+          } else if (!strcmp(header.name, "dinf")) {
+              result = ParseDinf(fileWrapper, header.size, byteOffset);
+          } else if (!strcmp(header.name, "iloc")) {
+              result = ParseIloc(fileWrapper, header.size, byteOffset);
+          } else if (!strcmp(header.name, "ipro")) {
+              result = ParseIpro(fileWrapper, header.size, byteOffset);
+          } else if (!strcmp(header.name, "iinf")) {
+              result = ParseIinf(fileWrapper, header.size, byteOffset);
+          } else if (!strcmp(header.name, "xml")) {
+              result = ParseXml(fileWrapper, header.size, byteOffset);
+          } else if (!strcmp(header.name, "bxml")) {
+              result = ParseBxml(fileWrapper, header.size, byteOffset);
+          } else if (!strcmp(header.name, "pitm")) {
+              result = ParsePitm(fileWrapper, header.size, byteOffset);
+          } else if (!strcmp(header.name, "fiin")) {
+              result = ParseFiin(fileWrapper, header.size, byteOffset);
+          } else if (!strcmp(header.name, "idat")) {
+              result = ParseIdat(fileWrapper, header.size, byteOffset);
+          } else if (!strcmp(header.name, "iref")) {
+              result = ParseIref(fileWrapper, header.size, byteOffset);
           }
           return result;
       });

--- a/src/boxes/file_level_boxes.h
+++ b/src/boxes/file_level_boxes.h
@@ -11,4 +11,6 @@ LovokStatusCode ParseMoov(FileWrapper *, uint64_t, uint64_t);
 
 LovokStatusCode ParseMoof(FileWrapper *, uint64_t, uint64_t);
 
+LovokStatusCode ParseMeta(FileWrapper *, uint64_t, uint64_t);
+
 #endif //LOVOK_FILE_LEVEL_BOXES_H

--- a/src/boxes/ipro_sub_boxes.cpp
+++ b/src/boxes/ipro_sub_boxes.cpp
@@ -1,0 +1,23 @@
+#include "../lovok_handle_internal.h"
+#include "ipro_sub_boxes.h"
+#include "sinf_sub_boxes.h"
+
+LovokStatusCode ParseSinf(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    byteOffset += 8;
+    length -= 8;
+    LovokStatusCode parseResults = ParseBoxes(fileWrapper,
+                                              length,
+                                              byteOffset,
+                                              [&fileWrapper] (const Box &header, uint64_t byteOffset) -> LovokStatusCode {
+          LovokStatusCode result = SUCCESS;
+          if (!strcmp(header.name, "frma")) {
+              result = ParseFrma(fileWrapper, header.size, byteOffset);
+          } else if (!strcmp(header.name, "schm")) {
+              result = ParseSchm(fileWrapper, header.size, byteOffset);
+          } else if (!strcmp(header.name, "schi")) {
+              result = ParseSchi(fileWrapper, header.size, byteOffset);
+          }
+          return result;
+      });
+    return parseResults;
+}

--- a/src/boxes/ipro_sub_boxes.h
+++ b/src/boxes/ipro_sub_boxes.h
@@ -1,0 +1,12 @@
+#include "box.h"
+#include "../lovok_handle_internal.h"
+#include "../include/lovok.h"
+#include "io/file_io.h"
+#include <functional>
+
+#ifndef LOVOK_IPRO_SUB_BOXES_H
+#define LOVOK_IPRO_SUB_BOXES_H
+
+LovokStatusCode ParseSinf(FileWrapper *, uint64_t, uint64_t);
+
+#endif //LOVOK_IPRO_SUB_BOXES_H

--- a/src/boxes/mdia_sub_boxes.cpp
+++ b/src/boxes/mdia_sub_boxes.cpp
@@ -7,7 +7,7 @@ LovokStatusCode ParseMdhd(FileWrapper * fileWrapper, uint64_t length, uint64_t b
     // todo if this is involved in an exploit
 }
 
-LovokStatusCode ParseHdlr(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
+LovokStatusCode ParseMdiaHdlr(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
     return SUCCESS;
     // todo if this is involved in an exploit
 }
@@ -36,7 +36,7 @@ LovokStatusCode ParseMinf(FileWrapper * fileWrapper, uint64_t length, uint64_t b
           } else if (!strcmp(header.name, "nmhd")) {
               result = ParseNmhd(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "dinf")) {
-              result = ParseDinf(fileWrapper, header.size, byteOffset);
+              result = ParseMinfDinf(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "stbl")) {
               result = ParseStbl(fileWrapper, header.size, byteOffset);
           }

--- a/src/boxes/mdia_sub_boxes.h
+++ b/src/boxes/mdia_sub_boxes.h
@@ -9,7 +9,7 @@
 
 LovokStatusCode ParseMdhd(FileWrapper *, uint64_t, uint64_t);
 
-LovokStatusCode ParseHdlr(FileWrapper *, uint64_t, uint64_t);
+LovokStatusCode ParseMdiaHdlr(FileWrapper *, uint64_t, uint64_t);
 
 LovokStatusCode ParseElng(FileWrapper *, uint64_t, uint64_t);
 

--- a/src/boxes/meta_sub_boxes.cpp
+++ b/src/boxes/meta_sub_boxes.cpp
@@ -2,6 +2,7 @@
 #include "meta_sub_boxes.h"
 #include "dinf_sub_boxes.h"
 #include "ipro_sub_boxes.h"
+#include "fiin_sub_boxes.h"
 
 LovokStatusCode ParseHdlr(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
     return SUCCESS;
@@ -66,8 +67,23 @@ LovokStatusCode ParsePitm(FileWrapper *fileWrapper, uint64_t length, uint64_t by
 }
 
 LovokStatusCode ParseFiin(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
-    //todo if this is involved in an exploit
+    byteOffset += 8;
+    length -= 8;
+    LovokStatusCode parseResults = ParseBoxes(fileWrapper,
+                                              length,
+                                              byteOffset,
+                                              [&fileWrapper] (const Box &header, uint64_t byteOffset) -> LovokStatusCode {
+          LovokStatusCode result = SUCCESS;
+          if (!strcmp(header.name, "paen")) {
+              result = ParsePaen(fileWrapper, header.size, byteOffset);
+          } else if (!strcmp(header.name, "segr")) {
+              result = ParseSegr(fileWrapper, header.size, byteOffset);
+          } else if (!strcmp(header.name, "gitn")) {
+              result = ParseGitn(fileWrapper, header.size, byteOffset);
+          }
+          return result;
+      });
+    return parseResults;
 }
 
 LovokStatusCode ParseIdat(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {

--- a/src/boxes/meta_sub_boxes.cpp
+++ b/src/boxes/meta_sub_boxes.cpp
@@ -1,0 +1,57 @@
+#include "../lovok_handle_internal.h"
+#include "meta_sub_boxes.h"
+
+LovokStatusCode ParseHdlr(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    return SUCCESS;
+    //todo if this is involved in an exploit
+}
+
+LovokStatusCode ParseDinf(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    return SUCCESS;
+    //todo if this is involved in an exploit
+}
+
+LovokStatusCode ParseIloc(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    return SUCCESS;
+    //todo if this is involved in an exploit
+}
+
+LovokStatusCode ParseIpro(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    return SUCCESS;
+    //todo if this is involved in an exploit
+}
+
+LovokStatusCode ParseIinf(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    return SUCCESS;
+    //todo if this is involved in an exploit
+}
+
+LovokStatusCode ParseXml(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    return SUCCESS;
+    //todo if this is involved in an exploit
+}
+
+LovokStatusCode ParseBxml(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    return SUCCESS;
+    //todo if this is involved in an exploit
+}
+
+LovokStatusCode ParsePitm(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    return SUCCESS;
+    //todo if this is involved in an exploit
+}
+
+LovokStatusCode ParseFiin(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    return SUCCESS;
+    //todo if this is involved in an exploit
+}
+
+LovokStatusCode ParseIdat(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    return SUCCESS;
+    //todo if this is involved in an exploit
+}
+
+LovokStatusCode ParseIref(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    return SUCCESS;
+    //todo if this is involved in an exploit
+}

--- a/src/boxes/meta_sub_boxes.cpp
+++ b/src/boxes/meta_sub_boxes.cpp
@@ -1,5 +1,7 @@
 #include "../lovok_handle_internal.h"
 #include "meta_sub_boxes.h"
+#include "dinf_sub_boxes.h"
+#include "ipro_sub_boxes.h"
 
 LovokStatusCode ParseHdlr(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
     return SUCCESS;
@@ -7,8 +9,19 @@ LovokStatusCode ParseHdlr(FileWrapper *fileWrapper, uint64_t length, uint64_t by
 }
 
 LovokStatusCode ParseDinf(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
-    //todo if this is involved in an exploit
+    byteOffset += 8;
+    length -= 8;
+    LovokStatusCode parseResults = ParseBoxes(fileWrapper,
+                                              length,
+                                              byteOffset,
+                                              [&fileWrapper] (const Box &header, uint64_t byteOffset) -> LovokStatusCode {
+          LovokStatusCode result = SUCCESS;
+          if (!strcmp(header.name, "dref")) {
+              result = ParseDref(fileWrapper, header.size, byteOffset);
+          }
+          return result;
+      });
+    return parseResults;
 }
 
 LovokStatusCode ParseIloc(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
@@ -17,8 +30,19 @@ LovokStatusCode ParseIloc(FileWrapper *fileWrapper, uint64_t length, uint64_t by
 }
 
 LovokStatusCode ParseIpro(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
-    //todo if this is involved in an exploit
+    byteOffset += 8;
+    length -= 8;
+    LovokStatusCode parseResults = ParseBoxes(fileWrapper,
+                                              length,
+                                              byteOffset,
+                                              [&fileWrapper] (const Box &header, uint64_t byteOffset) -> LovokStatusCode {
+          LovokStatusCode result = SUCCESS;
+          if (!strcmp(header.name, "sinf")) {
+              result = ParseSinf(fileWrapper, header.size, byteOffset);
+          }
+          return result;
+      });
+    return parseResults;
 }
 
 LovokStatusCode ParseIinf(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {

--- a/src/boxes/meta_sub_boxes.h
+++ b/src/boxes/meta_sub_boxes.h
@@ -1,0 +1,32 @@
+#include "box.h"
+#include "../lovok_handle_internal.h"
+#include "../include/lovok.h"
+#include "io/file_io.h"
+#include <functional>
+
+#ifndef LOVOK_META_SUB_BOXES_H
+#define LOVOK_META_SUB_BOXES_H
+
+LovokStatusCode ParseHdlr(FileWrapper *, uint64_t, uint64_t);
+
+LovokStatusCode ParseDinf(FileWrapper *, uint64_t, uint64_t);
+
+LovokStatusCode ParseIloc(FileWrapper *, uint64_t, uint64_t);
+
+LovokStatusCode ParseIpro(FileWrapper *, uint64_t, uint64_t);
+
+LovokStatusCode ParseIinf(FileWrapper *, uint64_t, uint64_t);
+
+LovokStatusCode ParseXml(FileWrapper *, uint64_t, uint64_t);
+
+LovokStatusCode ParseBxml(FileWrapper *, uint64_t, uint64_t);
+
+LovokStatusCode ParsePitm(FileWrapper *, uint64_t, uint64_t);
+
+LovokStatusCode ParseFiin(FileWrapper *, uint64_t, uint64_t);
+
+LovokStatusCode ParseIdat(FileWrapper *, uint64_t, uint64_t);
+
+LovokStatusCode ParseIref(FileWrapper *, uint64_t, uint64_t);
+
+#endif //LOVOK_META_SUB_BOXES_H

--- a/src/boxes/minf_sub_boxes.cpp
+++ b/src/boxes/minf_sub_boxes.cpp
@@ -28,7 +28,7 @@ LovokStatusCode ParseNmhd(FileWrapper * fileWrapper, uint64_t length, uint64_t b
     // todo if this is involved in an exploit
 }
 
-LovokStatusCode ParseDinf(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
+LovokStatusCode ParseMinfDinf(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
     byteOffset += 8;
     length -= 8;
     LovokStatusCode parseResults = ParseBoxes(fileWrapper,
@@ -81,15 +81,15 @@ LovokStatusCode ParseStbl(FileWrapper * fileWrapper, uint64_t length, uint64_t b
           } else if (!strcmp(header.name, "sdtp")) {
               result = ParseSdtp(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "sbgp")) {
-              result = ParseSbgp(fileWrapper, header.size, byteOffset);
+              result = ParseStblSbgp(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "sgpd")) {
-              result = ParseSgpd(fileWrapper, header.size, byteOffset);
+              result = ParseStblSgpd(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "subs")) {
-              result = ParseSubs(fileWrapper, header.size, byteOffset);
+              result = ParseStblSubs(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "saiz")) {
-              result = ParseSaiz(fileWrapper, header.size, byteOffset);
+              result = ParseStblSaiz(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "saio")) {
-              result = ParseSaio(fileWrapper, header.size, byteOffset);
+              result = ParseStblSaio(fileWrapper, header.size, byteOffset);
           }
           return result;
       });

--- a/src/boxes/minf_sub_boxes.h
+++ b/src/boxes/minf_sub_boxes.h
@@ -17,7 +17,7 @@ LovokStatusCode ParseSthd(FileWrapper *, uint64_t, uint64_t);
 
 LovokStatusCode ParseNmhd(FileWrapper *, uint64_t, uint64_t);
 
-LovokStatusCode ParseDinf(FileWrapper *, uint64_t, uint64_t);
+LovokStatusCode ParseMinfDinf(FileWrapper *, uint64_t, uint64_t);
 
 LovokStatusCode ParseStbl(FileWrapper *, uint64_t, uint64_t);
 

--- a/src/boxes/moof_sub_boxes.cpp
+++ b/src/boxes/moof_sub_boxes.cpp
@@ -1,0 +1,17 @@
+#include "../lovok_handle_internal.h"
+#include "moof_sub_boxes.h"
+
+LovokStatusCode ParseMfhd(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    return SUCCESS;
+    //todo if this is involved in an exploit
+}
+
+//LovokStatusCode ParseMeta(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+//    return SUCCESS;
+//    //todo if this is involved in an exploit
+//}
+
+LovokStatusCode ParseTraf(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    return SUCCESS;
+    //todo if this is involved in an exploit
+}

--- a/src/boxes/moof_sub_boxes.cpp
+++ b/src/boxes/moof_sub_boxes.cpp
@@ -1,17 +1,45 @@
 #include "../lovok_handle_internal.h"
 #include "moof_sub_boxes.h"
+#include "traf_sub_boxes.h"
 
 LovokStatusCode ParseMfhd(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
     return SUCCESS;
     //todo if this is involved in an exploit
 }
 
-//LovokStatusCode ParseMeta(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-//    return SUCCESS;
-//    //todo if this is involved in an exploit
-//}
-
-LovokStatusCode ParseTraf(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+LovokStatusCode ParseMoofMeta(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
     return SUCCESS;
     //todo if this is involved in an exploit
+}
+
+LovokStatusCode ParseTraf(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    byteOffset += 8;
+    length -= 8;
+    LovokStatusCode parseResults = ParseBoxes(fileWrapper,
+                                              length,
+                                              byteOffset,
+                                              [&fileWrapper] (const Box &header, uint64_t byteOffset) -> LovokStatusCode {
+          LovokStatusCode result = SUCCESS;
+          if (!strcmp(header.name, "tfhd")) {
+              result = ParseTfhd(fileWrapper, header.size, byteOffset);
+          } else if (!strcmp(header.name, "trun")) {
+              result = ParseTrun(fileWrapper, header.size, byteOffset);
+          } else if (!strcmp(header.name, "sbgp")) {
+              result = ParseTrafSbgp(fileWrapper, header.size, byteOffset);
+          } else if (!strcmp(header.name, "sgpd")) {
+              result = ParseTrafSgpd(fileWrapper, header.size, byteOffset);
+          } else if (!strcmp(header.name, "subs")) {
+              result = ParseTrafSubs(fileWrapper, header.size, byteOffset);
+          } else if (!strcmp(header.name, "saiz")) {
+              result = ParseTrafSaiz(fileWrapper, header.size, byteOffset);
+          } else if (!strcmp(header.name, "saio")) {
+              result = ParseTrafSaio(fileWrapper, header.size, byteOffset);
+          } else if (!strcmp(header.name, "tfdt")) {
+              result = ParseTfdt(fileWrapper, header.size, byteOffset);
+          } else if (!strcmp(header.name, "meta")) {
+              result = ParseTrafMeta(fileWrapper, header.size, byteOffset);
+          }
+          return result;
+      });
+    return parseResults;
 }

--- a/src/boxes/moof_sub_boxes.h
+++ b/src/boxes/moof_sub_boxes.h
@@ -9,7 +9,7 @@
 
 LovokStatusCode ParseMfhd(FileWrapper *, uint64_t, uint64_t);
 
-//LovokStatusCode ParseMeta(FileWrapper *, uint64_t, uint64_t);
+LovokStatusCode ParseMoofMeta(FileWrapper *, uint64_t, uint64_t);
 
 LovokStatusCode ParseTraf(FileWrapper *, uint64_t, uint64_t);
 

--- a/src/boxes/moof_sub_boxes.h
+++ b/src/boxes/moof_sub_boxes.h
@@ -1,0 +1,16 @@
+#include "box.h"
+#include "../lovok_handle_internal.h"
+#include "../include/lovok.h"
+#include "io/file_io.h"
+#include <functional>
+
+#ifndef LOVOK_MOOF_SUB_BOXES_H
+#define LOVOK_MOOF_SUB_BOXES_H
+
+LovokStatusCode ParseMfhd(FileWrapper *, uint64_t, uint64_t);
+
+//LovokStatusCode ParseMeta(FileWrapper *, uint64_t, uint64_t);
+
+LovokStatusCode ParseTraf(FileWrapper *, uint64_t, uint64_t);
+
+#endif //LOVOK_MOOF_SUB_BOXES_H

--- a/src/boxes/moov_sub_boxes.cpp
+++ b/src/boxes/moov_sub_boxes.cpp
@@ -20,7 +20,7 @@ LovokStatusCode ParseTrak(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           } else if (!strcmp(header.name, "edts")) {
               result = ParseEdts(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "meta")) {
-              result = ParseMeta(fileWrapper, header.size, byteOffset);
+              result = ParseTrakMeta(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "mdia")) {
               result = ParseMdia(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "udta")) {
@@ -36,7 +36,7 @@ LovokStatusCode ParseMvhd(FileWrapper *fileWrapper, uint64_t length, uint64_t by
     //todo if this is involved in an exploit
 }
 
-LovokStatusCode ParseMeta(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+LovokStatusCode ParseMoovMeta(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
     return SUCCESS;
     //todo if this is involved in an exploit
 }

--- a/src/boxes/moov_sub_boxes.h
+++ b/src/boxes/moov_sub_boxes.h
@@ -11,7 +11,7 @@ LovokStatusCode ParseTrak(FileWrapper *, uint64_t, uint64_t);
 
 LovokStatusCode ParseMvhd(FileWrapper *, uint64_t, uint64_t);
 
-LovokStatusCode ParseMeta(FileWrapper *, uint64_t, uint64_t);
+LovokStatusCode ParseMoovMeta(FileWrapper *, uint64_t, uint64_t);
 
 LovokStatusCode ParseMvex(FileWrapper *, uint64_t, uint64_t);
 

--- a/src/boxes/paen_sub_boxes.cpp
+++ b/src/boxes/paen_sub_boxes.cpp
@@ -1,0 +1,17 @@
+#include "../lovok_handle_internal.h"
+#include "paen_sub_boxes.h"
+
+LovokStatusCode ParseFire(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    return SUCCESS;
+    //todo if this is involved in an exploit
+}
+
+LovokStatusCode ParseFpar(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    return SUCCESS;
+    //todo if this is involved in an exploit
+}
+
+LovokStatusCode ParseFecr(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    return SUCCESS;
+    //todo if this is involved in an exploit
+}

--- a/src/boxes/paen_sub_boxes.h
+++ b/src/boxes/paen_sub_boxes.h
@@ -1,0 +1,16 @@
+#include "box.h"
+#include "../lovok_handle_internal.h"
+#include "../include/lovok.h"
+#include "io/file_io.h"
+#include <functional>
+
+#ifndef LOVOK_PAEN_SUB_BOXES_H
+#define LOVOK_PAEN_SUB_BOXES_H
+
+LovokStatusCode ParseFire(FileWrapper *, uint64_t, uint64_t);
+
+LovokStatusCode ParseFpar(FileWrapper *, uint64_t, uint64_t);
+
+LovokStatusCode ParseFecr(FileWrapper *, uint64_t, uint64_t);
+
+#endif //LOVOK_PAEN_SUB_BOXES_H

--- a/src/boxes/sinf_sub_boxes.cpp
+++ b/src/boxes/sinf_sub_boxes.cpp
@@ -1,0 +1,17 @@
+#include "../lovok_handle_internal.h"
+#include "sinf_sub_boxes.h"
+
+LovokStatusCode ParseFrma(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    return SUCCESS;
+    //todo if this is involved in an exploit
+}
+
+LovokStatusCode ParseSchm(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    return SUCCESS;
+    //todo if this is involved in an exploit
+}
+
+LovokStatusCode ParseSchi(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    return SUCCESS;
+    //todo if this is involved in an exploit
+}

--- a/src/boxes/sinf_sub_boxes.h
+++ b/src/boxes/sinf_sub_boxes.h
@@ -1,0 +1,16 @@
+#include "box.h"
+#include "../lovok_handle_internal.h"
+#include "../include/lovok.h"
+#include "io/file_io.h"
+#include <functional>
+
+#ifndef LOVOK_SINF_SUB_BOXES_H
+#define LOVOK_SINF_SUB_BOXES_H
+
+LovokStatusCode ParseFrma(FileWrapper *, uint64_t, uint64_t);
+
+LovokStatusCode ParseSchm(FileWrapper *, uint64_t, uint64_t);
+
+LovokStatusCode ParseSchi(FileWrapper *, uint64_t, uint64_t);
+
+#endif //LOVOK_SINF_SUB_BOXES_H

--- a/src/boxes/stbl_sub_boxes.cpp
+++ b/src/boxes/stbl_sub_boxes.cpp
@@ -71,27 +71,27 @@ LovokStatusCode ParseSdtp(FileWrapper * fileWrapper, uint64_t length, uint64_t b
     // todo if this is involved in an exploit
 }
 
-LovokStatusCode ParseSbgp(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
+LovokStatusCode ParseStblSbgp(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
     return SUCCESS;
     // todo if this is involved in an exploit
 }
 
-LovokStatusCode ParseSgpd(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
+LovokStatusCode ParseStblSgpd(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
     return SUCCESS;
     // todo if this is involved in an exploit
 }
 
-LovokStatusCode ParseSubs(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
+LovokStatusCode ParseStblSubs(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
     return SUCCESS;
     // todo if this is involved in an exploit
 }
 
-LovokStatusCode ParseSaiz(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
+LovokStatusCode ParseStblSaiz(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
     return SUCCESS;
     // todo if this is involved in an exploit
 }
 
-LovokStatusCode ParseSaio(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
+LovokStatusCode ParseStblSaio(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
     return SUCCESS;
     // todo if this is involved in an exploit
 }

--- a/src/boxes/stbl_sub_boxes.h
+++ b/src/boxes/stbl_sub_boxes.h
@@ -35,14 +35,14 @@ LovokStatusCode ParseStdp(FileWrapper *, uint64_t, uint64_t);
 
 LovokStatusCode ParseSdtp(FileWrapper *, uint64_t, uint64_t);
 
-LovokStatusCode ParseSbgp(FileWrapper *, uint64_t, uint64_t);
+LovokStatusCode ParseStblSbgp(FileWrapper *, uint64_t, uint64_t);
 
-LovokStatusCode ParseSgpd(FileWrapper *, uint64_t, uint64_t);
+LovokStatusCode ParseStblSgpd(FileWrapper *, uint64_t, uint64_t);
 
-LovokStatusCode ParseSubs(FileWrapper *, uint64_t, uint64_t);
+LovokStatusCode ParseStblSubs(FileWrapper *, uint64_t, uint64_t);
 
-LovokStatusCode ParseSaiz(FileWrapper *, uint64_t, uint64_t);
+LovokStatusCode ParseStblSaiz(FileWrapper *, uint64_t, uint64_t);
 
-LovokStatusCode ParseSaio(FileWrapper *, uint64_t, uint64_t);
+LovokStatusCode ParseStblSaio(FileWrapper *, uint64_t, uint64_t);
 
 #endif //LOVOK_STBL_SUB_BOXES_H

--- a/src/boxes/traf_sub_boxes.cpp
+++ b/src/boxes/traf_sub_boxes.cpp
@@ -1,0 +1,49 @@
+#include "../lovok_handle_internal.h"
+#include "traf_sub_boxes.h"
+
+LovokStatusCode ParseTfhd(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    return SUCCESS;
+    //todo if this is involved in an exploit
+}
+
+LovokStatusCode ParseTrun(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    return SUCCESS;
+    //todo if this is involved in an exploit
+}
+
+LovokStatusCode ParseTrafSbgp(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    return SUCCESS;
+    //todo if this is involved in an exploit
+}
+
+LovokStatusCode ParseTrafSgpd(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    return SUCCESS;
+    //todo if this is involved in an exploit
+}
+
+LovokStatusCode ParseTrafSubs(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    return SUCCESS;
+    //todo if this is involved in an exploit
+}
+
+LovokStatusCode ParseTrafSaiz(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    return SUCCESS;
+    //todo if this is involved in an exploit
+}
+
+LovokStatusCode ParseTrafSaio(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    return SUCCESS;
+    //todo if this is involved in an exploit
+}
+
+LovokStatusCode ParseTfdt(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    return SUCCESS;
+    //todo if this is involved in an exploit
+}
+
+LovokStatusCode ParseTrafMeta(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    return SUCCESS;
+    //todo if this is involved in an exploit
+}
+
+

--- a/src/boxes/traf_sub_boxes.h
+++ b/src/boxes/traf_sub_boxes.h
@@ -1,0 +1,28 @@
+#include "box.h"
+#include "../lovok_handle_internal.h"
+#include "../include/lovok.h"
+#include "io/file_io.h"
+#include <functional>
+
+#ifndef LOVOK_TRAF_SUB_BOXES_H
+#define LOVOK_TRAF_SUB_BOXES_H
+
+LovokStatusCode ParseTfhd(FileWrapper *, uint64_t, uint64_t);
+
+LovokStatusCode ParseTrun(FileWrapper *, uint64_t, uint64_t);
+
+LovokStatusCode ParseTrafSbgp(FileWrapper *, uint64_t, uint64_t);
+
+LovokStatusCode ParseTrafSgpd(FileWrapper *, uint64_t, uint64_t);
+
+LovokStatusCode ParseTrafSubs(FileWrapper *, uint64_t, uint64_t);
+
+LovokStatusCode ParseTrafSaiz(FileWrapper *, uint64_t, uint64_t);
+
+LovokStatusCode ParseTrafSaio(FileWrapper *, uint64_t, uint64_t);
+
+LovokStatusCode ParseTfdt(FileWrapper *, uint64_t, uint64_t);
+
+LovokStatusCode ParseTrafMeta(FileWrapper *, uint64_t, uint64_t);
+
+#endif //LOVOK_TRAF_SUB_BOXES_H

--- a/src/boxes/trak_sub_boxes.cpp
+++ b/src/boxes/trak_sub_boxes.cpp
@@ -34,10 +34,10 @@ LovokStatusCode ParseEdts(FileWrapper * fileWrapper, uint64_t length, uint64_t b
     return parseResults;
 }
 
-//LovokStatusCode ParseMeta(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) { // Redeclare here? Since it is a different level metadata box
-//    return SUCCESS;
-//    // todo if this is involved in an exploit
-//}
+LovokStatusCode ParseTrakMeta(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) { // Redeclare here? Since it is a different level metadata box
+    return SUCCESS;
+    // todo if this is involved in an exploit
+}
 
 LovokStatusCode ParseMdia(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
     byteOffset += 8;
@@ -50,7 +50,7 @@ LovokStatusCode ParseMdia(FileWrapper * fileWrapper, uint64_t length, uint64_t b
           if (!strcmp(header.name, "mdhd")) {
               result = ParseMdhd(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "hdlr")) {
-              result = ParseHdlr(fileWrapper, header.size, byteOffset);
+              result = ParseMdiaHdlr(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "elng")) {
               result = ParseElng(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "minf")) {

--- a/src/boxes/trak_sub_boxes.h
+++ b/src/boxes/trak_sub_boxes.h
@@ -15,7 +15,7 @@ LovokStatusCode ParseTrgr(FileWrapper *, uint64_t, uint64_t);
 
 LovokStatusCode ParseEdts(FileWrapper *, uint64_t, uint64_t);
 
-//LovokStatusCode ParseMeta(FileWrapper *, uint64_t, uint64_t); // Redeclare here? Since it is a different level metadata box
+LovokStatusCode ParseTrakMeta(FileWrapper *, uint64_t, uint64_t); // Redeclare here? Since it is a different level metadata box
 
 LovokStatusCode ParseMdia(FileWrapper *, uint64_t, uint64_t);
 

--- a/src/lovok_handle_internal.cpp
+++ b/src/lovok_handle_internal.cpp
@@ -94,6 +94,8 @@ LovokStatusCode ParseMp4(LOVOK_HANDLE_INTERNAL handle) {
             result = ParseMoov(fileWrapper, header.size, byteOffset);
         } else if (!strcmp(header.name, "moof")) {
             result = ParseMoof(fileWrapper, header.size, byteOffset);
+        } else if (!strcmp(header.name, "meta")) {
+            result = ParseMeta(fileWrapper, header.size, byteOffset);
         }
         return result;
     });


### PR DESCRIPTION
Recursively parse file level meta and moof boxes and their respective sub boxes. Also changed some method names so that they are unique even if the name of the sub boxes is the same. 

Resolves #54 
Resolves #51 
Resolves #48 