### PR TITLE
Refactored Lovok Handle

### DIFF
--- a/include/lovok.h
+++ b/include/lovok.h
@@ -11,7 +11,7 @@ enum LovokStatusCode {
     SUCCESS = 0,
     PARSE_ERROR = 1,
     INVALID_FILE = 2,
-    UNKNOWN_BOX,
+    UNKNOWN_BOX = 3,
 };
 
 typedef struct LovokHandleInternal *LOVOK_HANDLE;

--- a/include/lovok.h
+++ b/include/lovok.h
@@ -11,6 +11,7 @@ enum LovokStatusCode {
     SUCCESS = 0,
     PARSE_ERROR = 1,
     INVALID_FILE = 2,
+    UNKNOWN_BOX,
 };
 
 typedef struct LovokHandleInternal *LOVOK_HANDLE;

--- a/include/lovok.h
+++ b/include/lovok.h
@@ -1,3 +1,5 @@
+#include "../libs/io/file_io.h"
+
 #ifndef LOVOK_LOVOK_H
 #define LOVOK_LOVOK_H
 
@@ -14,6 +16,8 @@ enum LovokStatusCode {
 typedef struct LovokHandleInternal *LOVOK_HANDLE;
 
 LOVOK_HANDLE Lovok_create(const char *name);
+
+LOVOK_HANDLE Lovok_create_by_handle(FileWrapper *);
 
 LovokStatusCode valid_mp4(LOVOK_HANDLE);
 

--- a/src/lovok.cpp
+++ b/src/lovok.cpp
@@ -11,6 +11,13 @@ LOVOK_HANDLE Lovok_create(const char *name) {
     return handle;
 }
 
+LOVOK_HANDLE Lovok_create_by_handle(FileWrapper *wrapper) {
+    LOVOK_HANDLE handle = NULL;
+    handle = (LOVOK_HANDLE) malloc(sizeof(LOVOK_HANDLE_INTERNAL));
+    handle->wrapper = wrapper;
+    return handle;
+}
+
 void Lovok_destroy(LOVOK_HANDLE h) {
     FileWrapper_Close(h->wrapper);
     free(h);

--- a/src/lovok.cpp
+++ b/src/lovok.cpp
@@ -1,16 +1,18 @@
 #include <cstdlib>
 #include "../include/lovok.h"
+#include "../libs/io/file_io.h"
 #include "lovok_handle_internal.h"
 
 
 LOVOK_HANDLE Lovok_create(const char *name) {
     LOVOK_HANDLE handle = NULL;
     handle = (LOVOK_HANDLE) malloc(sizeof(LOVOK_HANDLE_INTERNAL));
-    handle->name = name;
+    handle->wrapper = FileWrapper_Open(name);
     return handle;
 }
 
 void Lovok_destroy(LOVOK_HANDLE h) {
+    FileWrapper_Close(h->wrapper);
     free(h);
 }
 

--- a/src/lovok_handle_internal.cpp
+++ b/src/lovok_handle_internal.cpp
@@ -80,7 +80,7 @@ LovokStatusCode ParseBoxes(FileWrapper *fileWrapper, uint64_t length, uint64_t b
 }
 
 LovokStatusCode ParseMp4(LOVOK_HANDLE_INTERNAL handle) {
-    FileWrapper *fileWrapper = FileWrapper_Open(handle->name);
+    FileWrapper *fileWrapper = handle->wrapper;
     if (!fileWrapper) {
         return PARSE_ERROR;
     }
@@ -99,6 +99,5 @@ LovokStatusCode ParseMp4(LOVOK_HANDLE_INTERNAL handle) {
         }
         return result;
     });
-    FileWrapper_Close(fileWrapper);
     return parseResults;
 }

--- a/src/lovok_handle_internal.h
+++ b/src/lovok_handle_internal.h
@@ -7,7 +7,7 @@
 #define LOVOK_LOVOK_HANDLE_INTERNAL_H
 
 typedef struct LovokHandleInternal {
-    const char * name;
+    FileWrapper *wrapper;
 } *LOVOK_HANDLE_INTERNAL;
 
 LovokStatusCode ParseBoxes(FileWrapper *, uint64_t, uint64_t, const std::function<LovokStatusCode(const Box &, uint64_t)> &);


### PR DESCRIPTION
Opens the file in the Lovok_create method so we don't hold a pointer, which could change, and stores it in a FileWrapper. Also Lovok_destroy now closes that FileWrapper, so ParseMp4 doesn't have to. 

Added a Lovok_create_by_handle(FileWrapper *fileWrapper) method to have another way of creating a LOVOK_HANDLE.

Resolves #58 
Resolves #59 