### PR TITLE
Suggestions for error handling for handle initializer

### DIFF
--- a/src/lovok.cpp
+++ b/src/lovok.cpp
@@ -6,19 +6,33 @@
 
 LOVOK_HANDLE Lovok_create(const char *name) {
     LOVOK_HANDLE handle = NULL;
+
     handle = (LOVOK_HANDLE) malloc(sizeof(LOVOK_HANDLE_INTERNAL));
-    handle->wrapper = FileWrapper_Open(name);
+    if (handle)
+    {
+        handle->wrapper = FileWrapper_Open(name);
+        if (handle->wrapper)
+            return handle;
+
+        free(handle);
+        handle = nullptr;
+    }
+
     return handle;
 }
 
 LOVOK_HANDLE Lovok_create_by_handle(FileWrapper *wrapper) {
     LOVOK_HANDLE handle = NULL;
     handle = (LOVOK_HANDLE) malloc(sizeof(LOVOK_HANDLE_INTERNAL));
-    handle->wrapper = wrapper;
+    if (handle)
+        handle->wrapper = wrapper;
     return handle;
 }
 
 void Lovok_destroy(LOVOK_HANDLE h) {
+    if (!h)
+        return;
+
     FileWrapper_Close(h->wrapper);
     free(h);
 }


### PR DESCRIPTION
This is a small change so I figure I can suggest it as a PR.

- Bubble up malloc failure and file open failure cases
- Make destroy function a no-op when called with NULL, following free() and fclose() conventions.