### PR TITLE
Enum refactor

### DIFF
--- a/include/lovok.h
+++ b/include/lovok.h
@@ -8,8 +8,8 @@ extern "C" {
 #endif
 
 enum LovokStatusCode {
-    SUCCESS = 0,
-    PARSE_ERROR = 1,
+    PARSE_ERROR = 0,
+    VALID_FILE = 1,
     INVALID_FILE = 2,
     UNKNOWN_BOX = 3,
 };

--- a/libs/io/file_io.c
+++ b/libs/io/file_io.c
@@ -65,7 +65,8 @@ static int fopen_seek(void *contextp, uint64_t pos) {
 static void fopen_close(void *contextp) {
     struct FileWrapper_StdIO *context = (struct FileWrapper_StdIO*) contextp;
     if (context->f) {
-      fclose(context->f);
+        fclose(context->f);
+        context->f = NULL;
     }
     free(context);
 }

--- a/src/boxes/dinf_sub_boxes.cpp
+++ b/src/boxes/dinf_sub_boxes.cpp
@@ -2,6 +2,6 @@
 #include "dinf_sub_boxes.h"
 
 LovokStatusCode ParseDref(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }

--- a/src/boxes/edts_sub_boxes.cpp
+++ b/src/boxes/edts_sub_boxes.cpp
@@ -2,6 +2,6 @@
 #include "edts_sub_boxes.h"
 
 LovokStatusCode ParseElst(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }

--- a/src/boxes/fiin_sub_boxes.cpp
+++ b/src/boxes/fiin_sub_boxes.cpp
@@ -1,4 +1,5 @@
 #include "../lovok_handle_internal.h"
+#include <iostream>
 #include "fiin_sub_boxes.h"
 #include "paen_sub_boxes.h"
 
@@ -16,6 +17,9 @@ LovokStatusCode ParsePaen(FileWrapper *fileWrapper, uint64_t length, uint64_t by
               result = ParseFpar(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "fecr")) {
               result = ParseFecr(fileWrapper, header.size, byteOffset);
+          } else {
+              std::cout << "Unknown box name in ParsePaen: ";
+              std::cout << header.name << std::endl;
           }
           return result;
       });

--- a/src/boxes/fiin_sub_boxes.cpp
+++ b/src/boxes/fiin_sub_boxes.cpp
@@ -9,7 +9,7 @@ LovokStatusCode ParsePaen(FileWrapper *fileWrapper, uint64_t length, uint64_t by
                                               length,
                                               byteOffset,
                                               [&fileWrapper] (const Box &header, uint64_t byteOffset) -> LovokStatusCode {
-          LovokStatusCode result = SUCCESS;
+          LovokStatusCode result = UNKNOWN_BOX;
           if (!strcmp(header.name, "fire")) {
               result = ParseFire(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "fpar")) {
@@ -23,11 +23,11 @@ LovokStatusCode ParsePaen(FileWrapper *fileWrapper, uint64_t length, uint64_t by
 }
 
 LovokStatusCode ParseSegr(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseGitn(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo if this is involved in an exploit
 }

--- a/src/boxes/fiin_sub_boxes.cpp
+++ b/src/boxes/fiin_sub_boxes.cpp
@@ -18,7 +18,7 @@ LovokStatusCode ParsePaen(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           } else if (!strcmp(header.name, "fecr")) {
               result = ParseFecr(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Unknown box name in ParsePaen: ";
+              std::cout << "Encountered unknown box while parsing 'paen' box: ";
               std::cout << header.name << std::endl;
           }
           return result;

--- a/src/boxes/fiin_sub_boxes.cpp
+++ b/src/boxes/fiin_sub_boxes.cpp
@@ -18,7 +18,7 @@ LovokStatusCode ParsePaen(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           } else if (!strcmp(header.name, "fecr")) {
               result = ParseFecr(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Encountered unknown box while parsing 'paen' box: ";
+              std::cout << "Encountered unknown box while parsing paen box: ";
               std::cout << header.name << std::endl;
           }
           return result;

--- a/src/boxes/file_level_boxes.cpp
+++ b/src/boxes/file_level_boxes.cpp
@@ -28,7 +28,7 @@ LovokStatusCode ParseMoov(FileWrapper *fileWrapper, uint64_t length, uint64_t by
         } else if (!strcmp(header.name, "udta")) {
             result = ParseMoovUdta(fileWrapper, header.size, byteOffset);
         } else {
-            std::cout << "Unknown box name in ParseMoov: ";
+            std::cout << "Encountered unknown box while parsing 'moov' box: ";
             std::cout << header.name << std::endl;
         }
         return result;
@@ -51,7 +51,7 @@ LovokStatusCode ParseMoof(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           } else if (!strcmp(header.name, "traf")) {
               result = ParseTraf(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Unknown box name in ParseMoof: ";
+              std::cout << "Encountered unknown box while parsing 'moof' box: ";
               std::cout << header.name << std::endl;
           }
           return result;
@@ -90,7 +90,7 @@ LovokStatusCode ParseMeta(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           } else if (!strcmp(header.name, "iref")) {
               result = ParseIref(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Unknown box name in ParseMeta File level: ";
+              std::cout << "Encountered unknown box while parsing 'meta' box: ";
               std::cout << header.name << std::endl;
           }
           return result;
@@ -111,7 +111,7 @@ LovokStatusCode ParseMfra(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           } else if (!strcmp(header.name, "mfro")) {
               result = ParseMfro(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Unknown box name in ParseMfra: ";
+              std::cout << "Encountered unknown box while parsing 'mfra' box: ";
               std::cout << header.name << std::endl;
           }
           return result;
@@ -130,7 +130,7 @@ LovokStatusCode ParseSkip(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           if (!strcmp(header.name, "udta")) {
               result = ParseSkipUdta(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Unknown box name in ParseSkip: ";
+              std::cout << "Encountered unknown box while parsing 'skip' box: ";
               std::cout << header.name << std::endl;
           }
           return result;
@@ -149,7 +149,7 @@ LovokStatusCode ParseMeco(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           if (!strcmp(header.name, "mere")) {
               result = ParseMere(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Unknown box name in ParseMeco: ";
+              std::cout << "Encountered unknown box while parsing 'meco' box: ";
               std::cout << header.name << std::endl;
           }
           return result;

--- a/src/boxes/file_level_boxes.cpp
+++ b/src/boxes/file_level_boxes.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include "file_level_boxes.h"
 #include "movie_box.h"
 #include "../lovok_handle_internal.h"
@@ -24,6 +25,11 @@ LovokStatusCode ParseMoov(FileWrapper *fileWrapper, uint64_t length, uint64_t by
             result = ParseMoovMeta(fileWrapper, header.size, byteOffset);
         } else if (!strcmp(header.name, "mvex")) {
             result = ParseMvex(fileWrapper, header.size, byteOffset);
+        } else if (!strcmp(header.name, "udta")) {
+            result = ParseMoovUdta(fileWrapper, header.size, byteOffset);
+        } else {
+            std::cout << "Unknown box name in ParseMoov: ";
+            std::cout << header.name << std::endl;
         }
         return result;
     });
@@ -44,6 +50,9 @@ LovokStatusCode ParseMoof(FileWrapper *fileWrapper, uint64_t length, uint64_t by
               result = ParseMoofMeta(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "traf")) {
               result = ParseTraf(fileWrapper, header.size, byteOffset);
+          } else {
+              std::cout << "Unknown box name in ParseMoof: ";
+              std::cout << header.name << std::endl;
           }
           return result;
       });
@@ -80,6 +89,9 @@ LovokStatusCode ParseMeta(FileWrapper *fileWrapper, uint64_t length, uint64_t by
               result = ParseIdat(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "iref")) {
               result = ParseIref(fileWrapper, header.size, byteOffset);
+          } else {
+              std::cout << "Unknown box name in ParseMeta File level: ";
+              std::cout << header.name << std::endl;
           }
           return result;
       });
@@ -98,6 +110,9 @@ LovokStatusCode ParseMfra(FileWrapper *fileWrapper, uint64_t length, uint64_t by
               result = ParseTfra(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "mfro")) {
               result = ParseMfro(fileWrapper, header.size, byteOffset);
+          } else {
+              std::cout << "Unknown box name in ParseMfra: ";
+              std::cout << header.name << std::endl;
           }
           return result;
       });
@@ -114,6 +129,9 @@ LovokStatusCode ParseSkip(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           LovokStatusCode result = UNKNOWN_BOX;
           if (!strcmp(header.name, "udta")) {
               result = ParseSkipUdta(fileWrapper, header.size, byteOffset);
+          } else {
+              std::cout << "Unknown box name in ParseSkip: ";
+              std::cout << header.name << std::endl;
           }
           return result;
       });
@@ -130,6 +148,9 @@ LovokStatusCode ParseMeco(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           LovokStatusCode result = UNKNOWN_BOX;
           if (!strcmp(header.name, "mere")) {
               result = ParseMere(fileWrapper, header.size, byteOffset);
+          } else {
+              std::cout << "Unknown box name in ParseMeco: ";
+              std::cout << header.name << std::endl;
           }
           return result;
       });

--- a/src/boxes/file_level_boxes.cpp
+++ b/src/boxes/file_level_boxes.cpp
@@ -28,7 +28,7 @@ LovokStatusCode ParseMoov(FileWrapper *fileWrapper, uint64_t length, uint64_t by
         } else if (!strcmp(header.name, "udta")) {
             result = ParseMoovUdta(fileWrapper, header.size, byteOffset);
         } else {
-            std::cout << "Encountered unknown box while parsing 'moov' box: ";
+            std::cout << "Encountered unknown box while parsing moov box: ";
             std::cout << header.name << std::endl;
         }
         return result;
@@ -51,7 +51,7 @@ LovokStatusCode ParseMoof(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           } else if (!strcmp(header.name, "traf")) {
               result = ParseTraf(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Encountered unknown box while parsing 'moof' box: ";
+              std::cout << "Encountered unknown box while parsing moof box: ";
               std::cout << header.name << std::endl;
           }
           return result;
@@ -90,7 +90,7 @@ LovokStatusCode ParseMeta(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           } else if (!strcmp(header.name, "iref")) {
               result = ParseIref(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Encountered unknown box while parsing 'meta' box: ";
+              std::cout << "Encountered unknown box while parsing meta box: ";
               std::cout << header.name << std::endl;
           }
           return result;
@@ -111,7 +111,7 @@ LovokStatusCode ParseMfra(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           } else if (!strcmp(header.name, "mfro")) {
               result = ParseMfro(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Encountered unknown box while parsing 'mfra' box: ";
+              std::cout << "Encountered unknown box while parsing mfra box: ";
               std::cout << header.name << std::endl;
           }
           return result;
@@ -130,7 +130,7 @@ LovokStatusCode ParseSkip(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           if (!strcmp(header.name, "udta")) {
               result = ParseSkipUdta(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Encountered unknown box while parsing 'skip' box: ";
+              std::cout << "Encountered unknown box while parsing skip box: ";
               std::cout << header.name << std::endl;
           }
           return result;
@@ -149,7 +149,7 @@ LovokStatusCode ParseMeco(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           if (!strcmp(header.name, "mere")) {
               result = ParseMere(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Encountered unknown box while parsing 'meco' box: ";
+              std::cout << "Encountered unknown box while parsing meco box: ";
               std::cout << header.name << std::endl;
           }
           return result;

--- a/src/boxes/file_level_boxes.cpp
+++ b/src/boxes/file_level_boxes.cpp
@@ -15,7 +15,7 @@ LovokStatusCode ParseMoov(FileWrapper *fileWrapper, uint64_t length, uint64_t by
                length,
                byteOffset,
                [&fileWrapper] (const Box &header, uint64_t byteOffset) -> LovokStatusCode {
-        LovokStatusCode result = SUCCESS;
+        LovokStatusCode result = UNKNOWN_BOX;
         if (!strcmp(header.name, "trak")) {
             result = ParseTrak(fileWrapper, header.size, byteOffset);
         } else if (!strcmp(header.name, "mvhd")) {
@@ -37,7 +37,7 @@ LovokStatusCode ParseMoof(FileWrapper *fileWrapper, uint64_t length, uint64_t by
                                               length,
                                               byteOffset,
                                               [&fileWrapper] (const Box &header, uint64_t byteOffset) -> LovokStatusCode {
-          LovokStatusCode result = SUCCESS;
+          LovokStatusCode result = UNKNOWN_BOX;
           if (!strcmp(header.name, "mfhd")) {
               result = ParseMfhd(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "meta")) {
@@ -57,7 +57,7 @@ LovokStatusCode ParseMeta(FileWrapper *fileWrapper, uint64_t length, uint64_t by
                                               length,
                                               byteOffset,
                                               [&fileWrapper] (const Box &header, uint64_t byteOffset) -> LovokStatusCode {
-          LovokStatusCode result = SUCCESS;
+          LovokStatusCode result = UNKNOWN_BOX;
           if (!strcmp(header.name, "hdlr")) {
               result = ParseHdlr(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "dinf")) {
@@ -93,7 +93,7 @@ LovokStatusCode ParseMfra(FileWrapper *fileWrapper, uint64_t length, uint64_t by
                                               length,
                                               byteOffset,
                                               [&fileWrapper] (const Box &header, uint64_t byteOffset) -> LovokStatusCode {
-          LovokStatusCode result = SUCCESS;
+          LovokStatusCode result = UNKNOWN_BOX;
           if (!strcmp(header.name, "tfra")) {
               result = ParseTfra(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "mfro")) {
@@ -111,7 +111,7 @@ LovokStatusCode ParseSkip(FileWrapper *fileWrapper, uint64_t length, uint64_t by
                                               length,
                                               byteOffset,
                                               [&fileWrapper] (const Box &header, uint64_t byteOffset) -> LovokStatusCode {
-          LovokStatusCode result = SUCCESS;
+          LovokStatusCode result = UNKNOWN_BOX;
           if (!strcmp(header.name, "udta")) {
               result = ParseSkipUdta(fileWrapper, header.size, byteOffset);
           }
@@ -127,7 +127,7 @@ LovokStatusCode ParseMeco(FileWrapper *fileWrapper, uint64_t length, uint64_t by
                                               length,
                                               byteOffset,
                                               [&fileWrapper] (const Box &header, uint64_t byteOffset) -> LovokStatusCode {
-          LovokStatusCode result = SUCCESS;
+          LovokStatusCode result = UNKNOWN_BOX;
           if (!strcmp(header.name, "mere")) {
               result = ParseMere(fileWrapper, header.size, byteOffset);
           }
@@ -137,41 +137,41 @@ LovokStatusCode ParseMeco(FileWrapper *fileWrapper, uint64_t length, uint64_t by
 }
 
 LovokStatusCode ParseFtyp(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
 LovokStatusCode ParsePdin(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseMdat(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseFree(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseStyp(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseSidx(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseSsix(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
 LovokStatusCode ParsePrft(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }

--- a/src/boxes/ipro_sub_boxes.cpp
+++ b/src/boxes/ipro_sub_boxes.cpp
@@ -18,7 +18,7 @@ LovokStatusCode ParseSinf(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           } else if (!strcmp(header.name, "schi")) {
               result = ParseSchi(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Unknown box name in ParseSing: ";
+              std::cout << "Encountered unknown box while parsing 'sinf' box: ";
               std::cout << header.name << std::endl;
           }
           return result;

--- a/src/boxes/ipro_sub_boxes.cpp
+++ b/src/boxes/ipro_sub_boxes.cpp
@@ -18,7 +18,7 @@ LovokStatusCode ParseSinf(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           } else if (!strcmp(header.name, "schi")) {
               result = ParseSchi(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Encountered unknown box while parsing 'sinf' box: ";
+              std::cout << "Encountered unknown box while parsing sinf box: ";
               std::cout << header.name << std::endl;
           }
           return result;

--- a/src/boxes/ipro_sub_boxes.cpp
+++ b/src/boxes/ipro_sub_boxes.cpp
@@ -9,7 +9,7 @@ LovokStatusCode ParseSinf(FileWrapper *fileWrapper, uint64_t length, uint64_t by
                                               length,
                                               byteOffset,
                                               [&fileWrapper] (const Box &header, uint64_t byteOffset) -> LovokStatusCode {
-          LovokStatusCode result = SUCCESS;
+          LovokStatusCode result = UNKNOWN_BOX;
           if (!strcmp(header.name, "frma")) {
               result = ParseFrma(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "schm")) {

--- a/src/boxes/ipro_sub_boxes.cpp
+++ b/src/boxes/ipro_sub_boxes.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include "../lovok_handle_internal.h"
 #include "ipro_sub_boxes.h"
 #include "sinf_sub_boxes.h"
@@ -16,6 +17,9 @@ LovokStatusCode ParseSinf(FileWrapper *fileWrapper, uint64_t length, uint64_t by
               result = ParseSchm(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "schi")) {
               result = ParseSchi(fileWrapper, header.size, byteOffset);
+          } else {
+              std::cout << "Unknown box name in ParseSing: ";
+              std::cout << header.name << std::endl;
           }
           return result;
       });

--- a/src/boxes/mdia_sub_boxes.cpp
+++ b/src/boxes/mdia_sub_boxes.cpp
@@ -41,7 +41,7 @@ LovokStatusCode ParseMinf(FileWrapper * fileWrapper, uint64_t length, uint64_t b
           } else if (!strcmp(header.name, "stbl")) {
               result = ParseStbl(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Unknown box name in ParseMinf: ";
+              std::cout << "Encountered unknown box while parsing 'minf' box: ";
               std::cout << header.name << std::endl;
           }
           return result;

--- a/src/boxes/mdia_sub_boxes.cpp
+++ b/src/boxes/mdia_sub_boxes.cpp
@@ -3,17 +3,17 @@
 #include "minf_sub_boxes.h"
 
 LovokStatusCode ParseMdhd(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseMdiaHdlr(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseElng(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
@@ -24,7 +24,7 @@ LovokStatusCode ParseMinf(FileWrapper * fileWrapper, uint64_t length, uint64_t b
                                               length,
                                               byteOffset,
                                               [&fileWrapper] (const Box &header, uint64_t byteOffset) -> LovokStatusCode {
-          LovokStatusCode result = SUCCESS;
+          LovokStatusCode result = UNKNOWN_BOX;
           if (!strcmp(header.name, "vmhd")) {
               result = ParseVmhd(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "smhd")) {

--- a/src/boxes/mdia_sub_boxes.cpp
+++ b/src/boxes/mdia_sub_boxes.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include "../lovok_handle_internal.h"
 #include "mdia_sub_boxes.h"
 #include "minf_sub_boxes.h"
@@ -39,6 +40,9 @@ LovokStatusCode ParseMinf(FileWrapper * fileWrapper, uint64_t length, uint64_t b
               result = ParseMinfDinf(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "stbl")) {
               result = ParseStbl(fileWrapper, header.size, byteOffset);
+          } else {
+              std::cout << "Unknown box name in ParseMinf: ";
+              std::cout << header.name << std::endl;
           }
           return result;
       });

--- a/src/boxes/mdia_sub_boxes.cpp
+++ b/src/boxes/mdia_sub_boxes.cpp
@@ -41,7 +41,7 @@ LovokStatusCode ParseMinf(FileWrapper * fileWrapper, uint64_t length, uint64_t b
           } else if (!strcmp(header.name, "stbl")) {
               result = ParseStbl(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Encountered unknown box while parsing 'minf' box: ";
+              std::cout << "Encountered unknown box while parsing minf box: ";
               std::cout << header.name << std::endl;
           }
           return result;

--- a/src/boxes/meco_sub_boxes.cpp
+++ b/src/boxes/meco_sub_boxes.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include "../lovok_handle_internal.h"
 #include "meco_sub_boxes.h"
 #include "mere_sub_boxes.h"
@@ -12,6 +13,9 @@ LovokStatusCode ParseMere(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           LovokStatusCode result = UNKNOWN_BOX;
           if (!strcmp(header.name, "meta")) {
               result = ParseMereMeta(fileWrapper, header.size, byteOffset);
+          } else {
+              std::cout << "Unknown box name in ParseMere: ";
+              std::cout << header.name << std::endl;
           }
           return result;
       });

--- a/src/boxes/meco_sub_boxes.cpp
+++ b/src/boxes/meco_sub_boxes.cpp
@@ -14,7 +14,7 @@ LovokStatusCode ParseMere(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           if (!strcmp(header.name, "meta")) {
               result = ParseMereMeta(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Encountered unknown box while parsing 'mere' box: ";
+              std::cout << "Encountered unknown box while parsing mere box: ";
               std::cout << header.name << std::endl;
           }
           return result;

--- a/src/boxes/meco_sub_boxes.cpp
+++ b/src/boxes/meco_sub_boxes.cpp
@@ -9,7 +9,7 @@ LovokStatusCode ParseMere(FileWrapper *fileWrapper, uint64_t length, uint64_t by
                                               length,
                                               byteOffset,
                                               [&fileWrapper] (const Box &header, uint64_t byteOffset) -> LovokStatusCode {
-          LovokStatusCode result = SUCCESS;
+          LovokStatusCode result = UNKNOWN_BOX;
           if (!strcmp(header.name, "meta")) {
               result = ParseMereMeta(fileWrapper, header.size, byteOffset);
           }

--- a/src/boxes/meco_sub_boxes.cpp
+++ b/src/boxes/meco_sub_boxes.cpp
@@ -14,7 +14,7 @@ LovokStatusCode ParseMere(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           if (!strcmp(header.name, "meta")) {
               result = ParseMereMeta(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Unknown box name in ParseMere: ";
+              std::cout << "Encountered unknown box while parsing 'mere' box: ";
               std::cout << header.name << std::endl;
           }
           return result;

--- a/src/boxes/mere_sub_boxes.cpp
+++ b/src/boxes/mere_sub_boxes.cpp
@@ -2,6 +2,6 @@
 #include "mere_sub_boxes.h"
 
 LovokStatusCode ParseMereMeta(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo: Handle known exploits if exploits are known
 }

--- a/src/boxes/meta_sub_boxes.cpp
+++ b/src/boxes/meta_sub_boxes.cpp
@@ -5,7 +5,7 @@
 #include "fiin_sub_boxes.h"
 
 LovokStatusCode ParseHdlr(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo if this is involved in an exploit
 }
 
@@ -16,7 +16,7 @@ LovokStatusCode ParseDinf(FileWrapper *fileWrapper, uint64_t length, uint64_t by
                                               length,
                                               byteOffset,
                                               [&fileWrapper] (const Box &header, uint64_t byteOffset) -> LovokStatusCode {
-          LovokStatusCode result = SUCCESS;
+          LovokStatusCode result = UNKNOWN_BOX;
           if (!strcmp(header.name, "dref")) {
               result = ParseDref(fileWrapper, header.size, byteOffset);
           }
@@ -26,7 +26,7 @@ LovokStatusCode ParseDinf(FileWrapper *fileWrapper, uint64_t length, uint64_t by
 }
 
 LovokStatusCode ParseIloc(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo if this is involved in an exploit
 }
 
@@ -37,7 +37,7 @@ LovokStatusCode ParseIpro(FileWrapper *fileWrapper, uint64_t length, uint64_t by
                                               length,
                                               byteOffset,
                                               [&fileWrapper] (const Box &header, uint64_t byteOffset) -> LovokStatusCode {
-          LovokStatusCode result = SUCCESS;
+          LovokStatusCode result = UNKNOWN_BOX;
           if (!strcmp(header.name, "sinf")) {
               result = ParseSinf(fileWrapper, header.size, byteOffset);
           }
@@ -47,22 +47,22 @@ LovokStatusCode ParseIpro(FileWrapper *fileWrapper, uint64_t length, uint64_t by
 }
 
 LovokStatusCode ParseIinf(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseXml(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseBxml(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo if this is involved in an exploit
 }
 
 LovokStatusCode ParsePitm(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo if this is involved in an exploit
 }
 
@@ -73,7 +73,7 @@ LovokStatusCode ParseFiin(FileWrapper *fileWrapper, uint64_t length, uint64_t by
                                               length,
                                               byteOffset,
                                               [&fileWrapper] (const Box &header, uint64_t byteOffset) -> LovokStatusCode {
-          LovokStatusCode result = SUCCESS;
+          LovokStatusCode result = UNKNOWN_BOX;
           if (!strcmp(header.name, "paen")) {
               result = ParsePaen(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "segr")) {
@@ -87,11 +87,11 @@ LovokStatusCode ParseFiin(FileWrapper *fileWrapper, uint64_t length, uint64_t by
 }
 
 LovokStatusCode ParseIdat(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseIref(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo if this is involved in an exploit
 }

--- a/src/boxes/meta_sub_boxes.cpp
+++ b/src/boxes/meta_sub_boxes.cpp
@@ -21,7 +21,7 @@ LovokStatusCode ParseDinf(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           if (!strcmp(header.name, "dref")) {
               result = ParseDref(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Unknown box name in ParseDinf: ";
+              std::cout << "Encountered unknown box while parsing 'dinf' box: ";
               std::cout << header.name << std::endl;
           }
           return result;
@@ -45,7 +45,7 @@ LovokStatusCode ParseIpro(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           if (!strcmp(header.name, "sinf")) {
               result = ParseSinf(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Unknown box name in ParseIpro: ";
+              std::cout << "Encountered unknown box while parsing 'iloc' box: ";
               std::cout << header.name << std::endl;
           }
           return result;
@@ -88,7 +88,7 @@ LovokStatusCode ParseFiin(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           } else if (!strcmp(header.name, "gitn")) {
               result = ParseGitn(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Unknown box name in ParseFiin: ";
+              std::cout << "Encountered unknown box while parsing 'fiin' box: ";
               std::cout << header.name << std::endl;
           }
           return result;

--- a/src/boxes/meta_sub_boxes.cpp
+++ b/src/boxes/meta_sub_boxes.cpp
@@ -21,7 +21,7 @@ LovokStatusCode ParseDinf(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           if (!strcmp(header.name, "dref")) {
               result = ParseDref(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Encountered unknown box while parsing 'dinf' box: ";
+              std::cout << "Encountered unknown box while parsing dinf box: ";
               std::cout << header.name << std::endl;
           }
           return result;
@@ -45,7 +45,7 @@ LovokStatusCode ParseIpro(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           if (!strcmp(header.name, "sinf")) {
               result = ParseSinf(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Encountered unknown box while parsing 'iloc' box: ";
+              std::cout << "Encountered unknown box while parsing iloc box: ";
               std::cout << header.name << std::endl;
           }
           return result;
@@ -88,7 +88,7 @@ LovokStatusCode ParseFiin(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           } else if (!strcmp(header.name, "gitn")) {
               result = ParseGitn(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Encountered unknown box while parsing 'fiin' box: ";
+              std::cout << "Encountered unknown box while parsing fiin box: ";
               std::cout << header.name << std::endl;
           }
           return result;

--- a/src/boxes/meta_sub_boxes.cpp
+++ b/src/boxes/meta_sub_boxes.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include "../lovok_handle_internal.h"
 #include "meta_sub_boxes.h"
 #include "dinf_sub_boxes.h"
@@ -19,6 +20,9 @@ LovokStatusCode ParseDinf(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           LovokStatusCode result = UNKNOWN_BOX;
           if (!strcmp(header.name, "dref")) {
               result = ParseDref(fileWrapper, header.size, byteOffset);
+          } else {
+              std::cout << "Unknown box name in ParseDinf: ";
+              std::cout << header.name << std::endl;
           }
           return result;
       });
@@ -40,6 +44,9 @@ LovokStatusCode ParseIpro(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           LovokStatusCode result = UNKNOWN_BOX;
           if (!strcmp(header.name, "sinf")) {
               result = ParseSinf(fileWrapper, header.size, byteOffset);
+          } else {
+              std::cout << "Unknown box name in ParseIpro: ";
+              std::cout << header.name << std::endl;
           }
           return result;
       });
@@ -80,6 +87,9 @@ LovokStatusCode ParseFiin(FileWrapper *fileWrapper, uint64_t length, uint64_t by
               result = ParseSegr(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "gitn")) {
               result = ParseGitn(fileWrapper, header.size, byteOffset);
+          } else {
+              std::cout << "Unknown box name in ParseFiin: ";
+              std::cout << header.name << std::endl;
           }
           return result;
       });

--- a/src/boxes/mfra_sub_boxes.cpp
+++ b/src/boxes/mfra_sub_boxes.cpp
@@ -2,11 +2,11 @@
 #include "mfra_sub_boxes.h"
 
 LovokStatusCode ParseTfra(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo: logic for exploit handling if exploit involved
 }
 
 LovokStatusCode ParseMfro(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo: logic for exploit handling if exploit involved
 }

--- a/src/boxes/minf_sub_boxes.cpp
+++ b/src/boxes/minf_sub_boxes.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include "../lovok_handle_internal.h"
 #include "minf_sub_boxes.h"
 #include "dinf_sub_boxes.h"
@@ -38,6 +39,9 @@ LovokStatusCode ParseMinfDinf(FileWrapper * fileWrapper, uint64_t length, uint64
           LovokStatusCode result = UNKNOWN_BOX;
           if (!strcmp(header.name, "dref")) {
               result = ParseDref(fileWrapper, header.size, byteOffset);
+          } else {
+              std::cout << "Unknown box name in ParseMinfDinf: ";
+              std::cout << header.name << std::endl;
           }
           return result;
       });
@@ -90,6 +94,9 @@ LovokStatusCode ParseStbl(FileWrapper * fileWrapper, uint64_t length, uint64_t b
               result = ParseStblSaiz(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "saio")) {
               result = ParseStblSaio(fileWrapper, header.size, byteOffset);
+          } else {
+              std::cout << "Unknown box name in ParseStbl: ";
+              std::cout << header.name << std::endl;
           }
           return result;
       });

--- a/src/boxes/minf_sub_boxes.cpp
+++ b/src/boxes/minf_sub_boxes.cpp
@@ -4,27 +4,27 @@
 #include "stbl_sub_boxes.h"
 
 LovokStatusCode ParseVmhd(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseSmhd(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseHmhd(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseSthd(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseNmhd(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
@@ -35,7 +35,7 @@ LovokStatusCode ParseMinfDinf(FileWrapper * fileWrapper, uint64_t length, uint64
                                               length,
                                               byteOffset,
                                               [&fileWrapper] (const Box &header, uint64_t byteOffset) -> LovokStatusCode {
-          LovokStatusCode result = SUCCESS;
+          LovokStatusCode result = UNKNOWN_BOX;
           if (!strcmp(header.name, "dref")) {
               result = ParseDref(fileWrapper, header.size, byteOffset);
           }
@@ -51,7 +51,7 @@ LovokStatusCode ParseStbl(FileWrapper * fileWrapper, uint64_t length, uint64_t b
                                               length,
                                               byteOffset,
                                               [&fileWrapper] (const Box &header, uint64_t byteOffset) -> LovokStatusCode {
-          LovokStatusCode result = SUCCESS;
+          LovokStatusCode result = UNKNOWN_BOX;
           if (!strcmp(header.name, "stsd")) {
               result = ParseStsd(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "stts")) {

--- a/src/boxes/minf_sub_boxes.cpp
+++ b/src/boxes/minf_sub_boxes.cpp
@@ -40,7 +40,7 @@ LovokStatusCode ParseMinfDinf(FileWrapper * fileWrapper, uint64_t length, uint64
           if (!strcmp(header.name, "dref")) {
               result = ParseDref(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Unknown box name in ParseMinfDinf: ";
+              std::cout << "Encountered unknown box while parsing 'dinf' box: ";
               std::cout << header.name << std::endl;
           }
           return result;
@@ -95,7 +95,7 @@ LovokStatusCode ParseStbl(FileWrapper * fileWrapper, uint64_t length, uint64_t b
           } else if (!strcmp(header.name, "saio")) {
               result = ParseStblSaio(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Unknown box name in ParseStbl: ";
+              std::cout << "Encountered unknown box while parsing 'stbl' box: ";
               std::cout << header.name << std::endl;
           }
           return result;

--- a/src/boxes/minf_sub_boxes.cpp
+++ b/src/boxes/minf_sub_boxes.cpp
@@ -40,7 +40,7 @@ LovokStatusCode ParseMinfDinf(FileWrapper * fileWrapper, uint64_t length, uint64
           if (!strcmp(header.name, "dref")) {
               result = ParseDref(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Encountered unknown box while parsing 'dinf' box: ";
+              std::cout << "Encountered unknown box while parsing dinf box: ";
               std::cout << header.name << std::endl;
           }
           return result;
@@ -95,7 +95,7 @@ LovokStatusCode ParseStbl(FileWrapper * fileWrapper, uint64_t length, uint64_t b
           } else if (!strcmp(header.name, "saio")) {
               result = ParseStblSaio(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Encountered unknown box while parsing 'stbl' box: ";
+              std::cout << "Encountered unknown box while parsing stbl box: ";
               std::cout << header.name << std::endl;
           }
           return result;

--- a/src/boxes/moof_sub_boxes.cpp
+++ b/src/boxes/moof_sub_boxes.cpp
@@ -40,7 +40,7 @@ LovokStatusCode ParseTraf(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           } else if (!strcmp(header.name, "meta")) {
               result = ParseTrafMeta(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Unknown box name in ParseTraf: ";
+              std::cout << "Encountered unknown box while parsing 'traf' box: ";
               std::cout << header.name << std::endl;
           }
           return result;

--- a/src/boxes/moof_sub_boxes.cpp
+++ b/src/boxes/moof_sub_boxes.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include "../lovok_handle_internal.h"
 #include "moof_sub_boxes.h"
 #include "traf_sub_boxes.h"
@@ -38,6 +39,9 @@ LovokStatusCode ParseTraf(FileWrapper *fileWrapper, uint64_t length, uint64_t by
               result = ParseTfdt(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "meta")) {
               result = ParseTrafMeta(fileWrapper, header.size, byteOffset);
+          } else {
+              std::cout << "Unknown box name in ParseTraf: ";
+              std::cout << header.name << std::endl;
           }
           return result;
       });

--- a/src/boxes/moof_sub_boxes.cpp
+++ b/src/boxes/moof_sub_boxes.cpp
@@ -40,7 +40,7 @@ LovokStatusCode ParseTraf(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           } else if (!strcmp(header.name, "meta")) {
               result = ParseTrafMeta(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Encountered unknown box while parsing 'traf' box: ";
+              std::cout << "Encountered unknown box while parsing traf box: ";
               std::cout << header.name << std::endl;
           }
           return result;

--- a/src/boxes/moof_sub_boxes.cpp
+++ b/src/boxes/moof_sub_boxes.cpp
@@ -3,12 +3,12 @@
 #include "traf_sub_boxes.h"
 
 LovokStatusCode ParseMfhd(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseMoofMeta(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo if this is involved in an exploit
 }
 
@@ -19,7 +19,7 @@ LovokStatusCode ParseTraf(FileWrapper *fileWrapper, uint64_t length, uint64_t by
                                               length,
                                               byteOffset,
                                               [&fileWrapper] (const Box &header, uint64_t byteOffset) -> LovokStatusCode {
-          LovokStatusCode result = SUCCESS;
+          LovokStatusCode result = UNKNOWN_BOX;
           if (!strcmp(header.name, "tfhd")) {
               result = ParseTfhd(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "trun")) {

--- a/src/boxes/moov_sub_boxes.cpp
+++ b/src/boxes/moov_sub_boxes.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include "../lovok_handle_internal.h"
 #include "moov_sub_boxes.h"
 #include "trak_sub_boxes.h"
@@ -25,6 +26,9 @@ LovokStatusCode ParseTrak(FileWrapper *fileWrapper, uint64_t length, uint64_t by
               result = ParseMdia(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "udta")) {
               result = ParseTrakUdta(fileWrapper, header.size, byteOffset);
+          } else {
+              std::cout << "Unknown box name in ParseTrak: ";
+              std::cout << header.name << std::endl;
           }
           return result;
       });
@@ -55,8 +59,16 @@ LovokStatusCode ParseMvex(FileWrapper *fileWrapper, uint64_t length, uint64_t by
               result = ParseTrex(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "leva")) {
               result = ParseLeva(fileWrapper, header.size, byteOffset);
+          } else {
+              std::cout << "Unknown box name in ParseMvex: ";
+              std::cout << header.name << std::endl;
           }
           return result;
       });
     return parseResults;
+}
+
+LovokStatusCode ParseMoovUdta(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
+    return VALID_FILE;
+    //todo if this is involved in an exploit
 }

--- a/src/boxes/moov_sub_boxes.cpp
+++ b/src/boxes/moov_sub_boxes.cpp
@@ -10,7 +10,7 @@ LovokStatusCode ParseTrak(FileWrapper *fileWrapper, uint64_t length, uint64_t by
                                               length,
                                               byteOffset,
                                               [&fileWrapper] (const Box &header, uint64_t byteOffset) -> LovokStatusCode {
-          LovokStatusCode result = SUCCESS;
+          LovokStatusCode result = UNKNOWN_BOX;
           if (!strcmp(header.name, "tkhd")) {
               result = ParseTkhd(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "tref")) {
@@ -32,12 +32,12 @@ LovokStatusCode ParseTrak(FileWrapper *fileWrapper, uint64_t length, uint64_t by
 }
 
 LovokStatusCode ParseMvhd(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseMoovMeta(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo if this is involved in an exploit
 }
 
@@ -48,7 +48,7 @@ LovokStatusCode ParseMvex(FileWrapper *fileWrapper, uint64_t length, uint64_t by
                                               length,
                                               byteOffset,
                                               [&fileWrapper] (const Box &header, uint64_t byteOffset) -> LovokStatusCode {
-          LovokStatusCode result = SUCCESS;
+          LovokStatusCode result = UNKNOWN_BOX;
           if (!strcmp(header.name, "mehd")) {
               result = ParseMehd(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "trex")) {

--- a/src/boxes/moov_sub_boxes.cpp
+++ b/src/boxes/moov_sub_boxes.cpp
@@ -27,7 +27,7 @@ LovokStatusCode ParseTrak(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           } else if (!strcmp(header.name, "udta")) {
               result = ParseTrakUdta(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Unknown box name in ParseTrak: ";
+              std::cout << "Encountered unknown box while parsing 'trak' box: ";
               std::cout << header.name << std::endl;
           }
           return result;
@@ -60,7 +60,7 @@ LovokStatusCode ParseMvex(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           } else if (!strcmp(header.name, "leva")) {
               result = ParseLeva(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Unknown box name in ParseMvex: ";
+              std::cout << "Encountered unknown box while parsing 'mvex' box: ";
               std::cout << header.name << std::endl;
           }
           return result;

--- a/src/boxes/moov_sub_boxes.cpp
+++ b/src/boxes/moov_sub_boxes.cpp
@@ -27,7 +27,7 @@ LovokStatusCode ParseTrak(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           } else if (!strcmp(header.name, "udta")) {
               result = ParseTrakUdta(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Encountered unknown box while parsing 'trak' box: ";
+              std::cout << "Encountered unknown box while parsing trak box: ";
               std::cout << header.name << std::endl;
           }
           return result;
@@ -60,7 +60,7 @@ LovokStatusCode ParseMvex(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           } else if (!strcmp(header.name, "leva")) {
               result = ParseLeva(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Encountered unknown box while parsing 'mvex' box: ";
+              std::cout << "Encountered unknown box while parsing mvex box: ";
               std::cout << header.name << std::endl;
           }
           return result;

--- a/src/boxes/moov_sub_boxes.h
+++ b/src/boxes/moov_sub_boxes.h
@@ -15,4 +15,6 @@ LovokStatusCode ParseMoovMeta(FileWrapper *, uint64_t, uint64_t);
 
 LovokStatusCode ParseMvex(FileWrapper *, uint64_t, uint64_t);
 
+LovokStatusCode ParseMoovUdta(FileWrapper *, uint64_t, uint64_t);
+
 #endif //LOVOK_MOOV_SUB_BOXES_H

--- a/src/boxes/mvex_sub_boxes.cpp
+++ b/src/boxes/mvex_sub_boxes.cpp
@@ -2,16 +2,16 @@
 #include "mvex_sub_boxes.h"
 
 LovokStatusCode ParseMehd(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseTrex(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseLeva(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo if this is involved in an exploit
 }

--- a/src/boxes/paen_sub_boxes.cpp
+++ b/src/boxes/paen_sub_boxes.cpp
@@ -2,16 +2,16 @@
 #include "paen_sub_boxes.h"
 
 LovokStatusCode ParseFire(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseFpar(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseFecr(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo if this is involved in an exploit
 }

--- a/src/boxes/sinf_sub_boxes.cpp
+++ b/src/boxes/sinf_sub_boxes.cpp
@@ -2,16 +2,16 @@
 #include "sinf_sub_boxes.h"
 
 LovokStatusCode ParseFrma(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseSchm(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseSchi(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo if this is involved in an exploit
 }

--- a/src/boxes/skip_sub_boxes.cpp
+++ b/src/boxes/skip_sub_boxes.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include "../lovok_handle_internal.h"
 #include "skipudta_sub_boxes.h"
 
@@ -15,6 +16,9 @@ LovokStatusCode ParseSkipUdta(FileWrapper *fileWrapper, uint64_t length, uint64_
               result = ParseTsel(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "strk")) {
               result = ParseStrk(fileWrapper, header.size, byteOffset);
+          } else {
+              std::cout << "Unknown box name in ParseSkipUdta: ";
+              std::cout << header.name << std::endl;
           }
           return result;
       });

--- a/src/boxes/skip_sub_boxes.cpp
+++ b/src/boxes/skip_sub_boxes.cpp
@@ -17,7 +17,7 @@ LovokStatusCode ParseSkipUdta(FileWrapper *fileWrapper, uint64_t length, uint64_
           } else if (!strcmp(header.name, "strk")) {
               result = ParseStrk(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Unknown box name in ParseSkipUdta: ";
+              std::cout << "Encountered unknown box while parsing 'udta' box: ";
               std::cout << header.name << std::endl;
           }
           return result;

--- a/src/boxes/skip_sub_boxes.cpp
+++ b/src/boxes/skip_sub_boxes.cpp
@@ -8,7 +8,7 @@ LovokStatusCode ParseSkipUdta(FileWrapper *fileWrapper, uint64_t length, uint64_
                                               length,
                                               byteOffset,
                                               [&fileWrapper] (const Box &header, uint64_t byteOffset) -> LovokStatusCode {
-          LovokStatusCode result = SUCCESS;
+          LovokStatusCode result = UNKNOWN_BOX;
           if (!strcmp(header.name, "cprt")) {
               result = ParseCprt(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "tsel")) {

--- a/src/boxes/skip_sub_boxes.cpp
+++ b/src/boxes/skip_sub_boxes.cpp
@@ -17,7 +17,7 @@ LovokStatusCode ParseSkipUdta(FileWrapper *fileWrapper, uint64_t length, uint64_
           } else if (!strcmp(header.name, "strk")) {
               result = ParseStrk(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Encountered unknown box while parsing 'udta' box: ";
+              std::cout << "Encountered unknown box while parsing udta box: ";
               std::cout << header.name << std::endl;
           }
           return result;

--- a/src/boxes/skipudta_sub_boxes.cpp
+++ b/src/boxes/skipudta_sub_boxes.cpp
@@ -3,12 +3,12 @@
 #include "strk_sub_boxes.h"
 
 LovokStatusCode ParseCprt(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo: Handling exploit for box if one is known
 }
 
 LovokStatusCode ParseTsel(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo: Handling exploit for box if one is known
 }
 
@@ -19,7 +19,7 @@ LovokStatusCode ParseStrk(FileWrapper *fileWrapper, uint64_t length, uint64_t by
                                               length,
                                               byteOffset,
                                               [&fileWrapper] (const Box &header, uint64_t byteOffset) -> LovokStatusCode {
-          LovokStatusCode result = SUCCESS;
+          LovokStatusCode result = UNKNOWN_BOX;
           if (!strcmp(header.name, "stri")) {
               result = ParseStri(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "strd")) {

--- a/src/boxes/skipudta_sub_boxes.cpp
+++ b/src/boxes/skipudta_sub_boxes.cpp
@@ -26,7 +26,7 @@ LovokStatusCode ParseStrk(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           } else if (!strcmp(header.name, "strd")) {
               result = ParseStrd(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Encountered unknown box while parsing 'strk' box: ";
+              std::cout << "Encountered unknown box while parsing strk box: ";
               std::cout << header.name << std::endl;
           }
           return result;

--- a/src/boxes/skipudta_sub_boxes.cpp
+++ b/src/boxes/skipudta_sub_boxes.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include "../lovok_handle_internal.h"
 #include "skip_sub_boxes.h"
 #include "strk_sub_boxes.h"
@@ -24,6 +25,9 @@ LovokStatusCode ParseStrk(FileWrapper *fileWrapper, uint64_t length, uint64_t by
               result = ParseStri(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "strd")) {
               result = ParseStrd(fileWrapper, header.size, byteOffset);
+          } else {
+              std::cout << "Unknown box name in ParseStrk: ";
+              std::cout << header.name << std::endl;
           }
           return result;
       });

--- a/src/boxes/skipudta_sub_boxes.cpp
+++ b/src/boxes/skipudta_sub_boxes.cpp
@@ -26,7 +26,7 @@ LovokStatusCode ParseStrk(FileWrapper *fileWrapper, uint64_t length, uint64_t by
           } else if (!strcmp(header.name, "strd")) {
               result = ParseStrd(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Unknown box name in ParseStrk: ";
+              std::cout << "Encountered unknown box while parsing 'strk' box: ";
               std::cout << header.name << std::endl;
           }
           return result;

--- a/src/boxes/stbl_sub_boxes.cpp
+++ b/src/boxes/stbl_sub_boxes.cpp
@@ -2,96 +2,96 @@
 #include "stbl_sub_boxes.h"
 
 LovokStatusCode ParseStsd(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseStts(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseCtts(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseCslg(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseStsc(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseStsz(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseStz2(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseStco(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseCo64(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseStss(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseStsh(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
 LovokStatusCode ParsePadb(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseStdp(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseSdtp(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseStblSbgp(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseStblSgpd(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseStblSubs(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseStblSaiz(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseStblSaio(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }

--- a/src/boxes/strk_sub_boxes.cpp
+++ b/src/boxes/strk_sub_boxes.cpp
@@ -2,11 +2,11 @@
 #include "strk_sub_boxes.h"
 
 LovokStatusCode ParseStri(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo: Handling exploit for box if one is known
 }
 
 LovokStatusCode ParseStrd(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo: Handling exploit for box if one is known
 }

--- a/src/boxes/traf_sub_boxes.cpp
+++ b/src/boxes/traf_sub_boxes.cpp
@@ -2,47 +2,47 @@
 #include "traf_sub_boxes.h"
 
 LovokStatusCode ParseTfhd(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseTrun(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseTrafSbgp(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseTrafSgpd(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseTrafSubs(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseTrafSaiz(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseTrafSaio(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseTfdt(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseTrafMeta(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     //todo if this is involved in an exploit
 }
 

--- a/src/boxes/trak_sub_boxes.cpp
+++ b/src/boxes/trak_sub_boxes.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include "../lovok_handle_internal.h"
 #include "trak_sub_boxes.h"
 #include "edts_sub_boxes.h"
@@ -26,8 +27,11 @@ LovokStatusCode ParseEdts(FileWrapper * fileWrapper, uint64_t length, uint64_t b
                                               byteOffset,
                                               [&fileWrapper] (const Box &header, uint64_t byteOffset) -> LovokStatusCode {
           LovokStatusCode result = UNKNOWN_BOX;
-          if (!strcmp(header.name, "edts")) {
-              result = ParseEdts(fileWrapper, header.size, byteOffset);
+          if (!strcmp(header.name, "elst")) {
+              result = ParseElst(fileWrapper, header.size, byteOffset);
+          } else {
+              std::cout << "Unknown box name in ParseEdts: ";
+              std::cout << header.name << std::endl;
           }
           return result;
         });
@@ -55,6 +59,9 @@ LovokStatusCode ParseMdia(FileWrapper * fileWrapper, uint64_t length, uint64_t b
               result = ParseElng(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "minf")) {
               result = ParseMinf(fileWrapper, header.size, byteOffset);
+          } else {
+              std::cout << "Unknown box name in ParseMdia: ";
+              std::cout << header.name << std::endl;
           }
           return result;
       });

--- a/src/boxes/trak_sub_boxes.cpp
+++ b/src/boxes/trak_sub_boxes.cpp
@@ -30,7 +30,7 @@ LovokStatusCode ParseEdts(FileWrapper * fileWrapper, uint64_t length, uint64_t b
           if (!strcmp(header.name, "elst")) {
               result = ParseElst(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Unknown box name in ParseEdts: ";
+              std::cout << "Encountered unknown box while parsing 'edts' box: ";
               std::cout << header.name << std::endl;
           }
           return result;
@@ -60,7 +60,7 @@ LovokStatusCode ParseMdia(FileWrapper * fileWrapper, uint64_t length, uint64_t b
           } else if (!strcmp(header.name, "minf")) {
               result = ParseMinf(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Unknown box name in ParseMdia: ";
+              std::cout << "Encountered unknown box while parsing 'mdia' box: ";
               std::cout << header.name << std::endl;
           }
           return result;

--- a/src/boxes/trak_sub_boxes.cpp
+++ b/src/boxes/trak_sub_boxes.cpp
@@ -4,17 +4,17 @@
 #include "mdia_sub_boxes.h"
 
 LovokStatusCode ParseTkhd(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseTref(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
 LovokStatusCode ParseTrgr(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
@@ -25,7 +25,7 @@ LovokStatusCode ParseEdts(FileWrapper * fileWrapper, uint64_t length, uint64_t b
                                               length,
                                               byteOffset,
                                               [&fileWrapper] (const Box &header, uint64_t byteOffset) -> LovokStatusCode {
-          LovokStatusCode result = SUCCESS;
+          LovokStatusCode result = UNKNOWN_BOX;
           if (!strcmp(header.name, "edts")) {
               result = ParseEdts(fileWrapper, header.size, byteOffset);
           }
@@ -35,7 +35,7 @@ LovokStatusCode ParseEdts(FileWrapper * fileWrapper, uint64_t length, uint64_t b
 }
 
 LovokStatusCode ParseTrakMeta(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) { // Redeclare here? Since it is a different level metadata box
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }
 
@@ -46,7 +46,7 @@ LovokStatusCode ParseMdia(FileWrapper * fileWrapper, uint64_t length, uint64_t b
                                               length,
                                               byteOffset,
                                               [&fileWrapper] (const Box &header, uint64_t byteOffset) -> LovokStatusCode {
-          LovokStatusCode result = SUCCESS;
+          LovokStatusCode result = UNKNOWN_BOX;
           if (!strcmp(header.name, "mdhd")) {
               result = ParseMdhd(fileWrapper, header.size, byteOffset);
           } else if (!strcmp(header.name, "hdlr")) {
@@ -62,6 +62,6 @@ LovokStatusCode ParseMdia(FileWrapper * fileWrapper, uint64_t length, uint64_t b
 }
 
 LovokStatusCode ParseTrakUdta(FileWrapper * fileWrapper, uint64_t length, uint64_t byteOffset) {
-    return SUCCESS;
+    return VALID_FILE;
     // todo if this is involved in an exploit
 }

--- a/src/boxes/trak_sub_boxes.cpp
+++ b/src/boxes/trak_sub_boxes.cpp
@@ -30,7 +30,7 @@ LovokStatusCode ParseEdts(FileWrapper * fileWrapper, uint64_t length, uint64_t b
           if (!strcmp(header.name, "elst")) {
               result = ParseElst(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Encountered unknown box while parsing 'edts' box: ";
+              std::cout << "Encountered unknown box while parsing edts box: ";
               std::cout << header.name << std::endl;
           }
           return result;
@@ -60,7 +60,7 @@ LovokStatusCode ParseMdia(FileWrapper * fileWrapper, uint64_t length, uint64_t b
           } else if (!strcmp(header.name, "minf")) {
               result = ParseMinf(fileWrapper, header.size, byteOffset);
           } else {
-              std::cout << "Encountered unknown box while parsing 'mdia' box: ";
+              std::cout << "Encountered unknown box while parsing mdia box: ";
               std::cout << header.name << std::endl;
           }
           return result;

--- a/src/lovok.cpp
+++ b/src/lovok.cpp
@@ -1,4 +1,5 @@
 #include <cstdlib>
+#include <iostream>
 #include "../include/lovok.h"
 #include "../libs/io/file_io.h"
 #include "lovok_handle_internal.h"
@@ -38,5 +39,9 @@ void Lovok_destroy(LOVOK_HANDLE h) {
 }
 
 LovokStatusCode valid_mp4(LOVOK_HANDLE h) {
-    return ParseMp4(h);
+    LovokStatusCode fileStatus = ParseMp4(h);
+    if (fileStatus == VALID_FILE || fileStatus == UNKNOWN_BOX) {
+        return VALID_FILE;
+    }
+    return fileStatus;
 }

--- a/src/lovok_handle_internal.cpp
+++ b/src/lovok_handle_internal.cpp
@@ -118,7 +118,7 @@ LovokStatusCode ParseMp4(LOVOK_HANDLE_INTERNAL handle) {
         } else if (!strcmp(header.name, "prft")) {
             result = ParsePrft(fileWrapper, header.size, byteOffset);
         } else {
-            std::cout << "Unknown box name in ParseMp4: ";
+            std::cout << "Encountered unknown box while parsing mp4 top level boxes: ";
             std::cout << header.name << std::endl;
         }
         return result;

--- a/src/lovok_handle_internal.cpp
+++ b/src/lovok_handle_internal.cpp
@@ -64,7 +64,7 @@ LovokStatusCode ParseBoxes(FileWrapper *fileWrapper, uint64_t length, uint64_t b
 
         // Parse Boxes within this box with function f
         LovokStatusCode boxResult = f(header, byteOffset);
-        if (boxResult != VALID_FILE) {
+        if (boxResult != VALID_FILE && boxResult != UNKNOWN_BOX) {
             return boxResult;
         }
         // seek to next box

--- a/src/lovok_handle_internal.cpp
+++ b/src/lovok_handle_internal.cpp
@@ -1,5 +1,6 @@
 #include <functional>
 #include <cstring>
+#include <iostream>
 #include "lovok_handle_internal.h"
 #include "io/file_io.h"
 #include "boxes/box.h"
@@ -58,20 +59,17 @@ LovokStatusCode ParseBoxes(FileWrapper *fileWrapper, uint64_t length, uint64_t b
         Box header = Box();
         LovokStatusCode parsedHeader = ParseHeader(fileWrapper, &header);
         if (parsedHeader != VALID_FILE) {
-            FileWrapper_Close(fileWrapper);
             return PARSE_ERROR;
         }
 
         // Parse Boxes within this box with function f
         LovokStatusCode boxResult = f(header, byteOffset);
         if (boxResult != VALID_FILE) {
-            FileWrapper_Close(fileWrapper);
             return boxResult;
         }
         // seek to next box
         int err = FileWrapper_Seek(fileWrapper, byteOffset + header.size);
         if (err != 0) {
-            FileWrapper_Close(fileWrapper);
             return PARSE_ERROR;
         }
         byteOffset += header.size;
@@ -119,6 +117,9 @@ LovokStatusCode ParseMp4(LOVOK_HANDLE_INTERNAL handle) {
             result = ParseSsix(fileWrapper, header.size, byteOffset);
         } else if (!strcmp(header.name, "prft")) {
             result = ParsePrft(fileWrapper, header.size, byteOffset);
+        } else {
+            std::cout << "Unknown box name in ParseMp4: ";
+            std::cout << header.name << std::endl;
         }
         return result;
     });

--- a/src/lovok_handle_internal.cpp
+++ b/src/lovok_handle_internal.cpp
@@ -49,7 +49,7 @@ LovokStatusCode ParseHeader(FileWrapper *fileWrapper, Box *header) {
     } else {
         header->size = boxSize;
     }
-    return SUCCESS;
+    return VALID_FILE;
 }
 
 LovokStatusCode ParseBoxes(FileWrapper *fileWrapper, uint64_t length, uint64_t byteOffset, const std::function<LovokStatusCode(const Box &, uint64_t)> &f) {
@@ -57,14 +57,14 @@ LovokStatusCode ParseBoxes(FileWrapper *fileWrapper, uint64_t length, uint64_t b
     while (length > 0) {
         Box header = Box();
         LovokStatusCode parsedHeader = ParseHeader(fileWrapper, &header);
-        if (parsedHeader != SUCCESS) {
+        if (parsedHeader != VALID_FILE) {
             FileWrapper_Close(fileWrapper);
             return PARSE_ERROR;
         }
 
         // Parse Boxes within this box with function f
         LovokStatusCode boxResult = f(header, byteOffset);
-        if (boxResult != SUCCESS) {
+        if (boxResult != VALID_FILE) {
             FileWrapper_Close(fileWrapper);
             return boxResult;
         }
@@ -77,7 +77,7 @@ LovokStatusCode ParseBoxes(FileWrapper *fileWrapper, uint64_t length, uint64_t b
         byteOffset += header.size;
         length -= header.size;
     }
-    return SUCCESS;
+    return VALID_FILE;
 }
 
 LovokStatusCode ParseMp4(LOVOK_HANDLE_INTERNAL handle) {
@@ -90,7 +90,7 @@ LovokStatusCode ParseMp4(LOVOK_HANDLE_INTERNAL handle) {
     LovokStatusCode parseResults = ParseBoxes(fileWrapper, length, byteOffset,
                                               [&fileWrapper] (const Box &header, uint64_t byteOffset) -> LovokStatusCode {
         // TODO add logic for Moov and other top level boxes
-        LovokStatusCode result = SUCCESS;
+        LovokStatusCode result = UNKNOWN_BOX;
         if (!strcmp(header.name, "moov")) {
             result = ParseMoov(fileWrapper, header.size, byteOffset);
         } else if (!strcmp(header.name, "moof")) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,7 +6,6 @@ add_test(NAME test_open_file COMMAND test_open_file)
 set_tests_properties(test_open_file PROPERTIES
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-
 add_executable(test_read_first_box test_open_files/test_read_first_box.cpp)
 target_link_libraries(test_read_first_box file_io)
 add_test(NAME test_read_first_box COMMAND test_read_first_box)

--- a/tests/test_open_files/test_parse_header.cpp
+++ b/tests/test_open_files/test_parse_header.cpp
@@ -10,7 +10,7 @@ int main(int argc, char **argv) {
       return 1;
     }
     LovokStatusCode valid = valid_mp4(handle);
-    if (valid != SUCCESS) {
+    if (valid != VALID_FILE) {
         std::cout << "Error validating mp4 file" << std::endl;
         return 1;
     }


### PR DESCRIPTION
Renamed and reordered status code enums. Sets initial status before box parsing to be UNKOWN_BOX, instead of VALID_FILE. 

Resolves #70 
Resolves #71 