### PR TITLE
Lower required cmake version for Debian Stable.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.18)
 project(lovok)
 
 set(CMAKE_CXX_STANDARD 14)


### PR DESCRIPTION
Current main branch does not compile on Debian Stable due to this. Seems to build ok with this version.