### PR TITLE
Proposed logging mechanism

### DIFF
--- a/include/lovok.h
+++ b/include/lovok.h
@@ -1,4 +1,5 @@
 #include "../libs/io/file_io.h"
+#include <stdarg.h>
 
 #ifndef LOVOK_LOVOK_H
 #define LOVOK_LOVOK_H
@@ -19,6 +20,13 @@ typedef struct LovokHandleInternal *LOVOK_HANDLE;
 LOVOK_HANDLE Lovok_create(const char *name);
 
 LOVOK_HANDLE Lovok_create_by_handle(FileWrapper *);
+
+void Lovok_set_logger(LOVOK_HANDLE h, void (*fn)(void *ctx, const char *msg, size_t len), void *ctx);
+
+void Lovok_log(LOVOK_HANDLE h, const char *msg, size_t n);
+void Lovok_log_puts(LOVOK_HANDLE h, const char *msg);
+void Lovok_log_printf(LOVOK_HANDLE h, const char *fmt, ...);
+void Lovok_log_vprintf(LOVOK_HANDLE h, const char *fmt, va_list ap);
 
 LovokStatusCode valid_mp4(LOVOK_HANDLE);
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(lovok_internal
+        log.cpp
         lovok.cpp
         lovok_handle_internal.cpp
         boxes/box.cpp

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -1,0 +1,36 @@
+#include "../include/lovok.h"
+#include "lovok_handle_internal.h"
+
+#include <string.h>
+
+void Lovok_set_logger(LOVOK_HANDLE h, void (*fn)(void *ctx, const char *msg, size_t len), void *ctx) {
+    if (h) {
+        h->log_callback = fn;
+        h->log_context = ctx;
+    }
+}
+
+void Lovok_log(LOVOK_HANDLE h, const char *msg, size_t n) {
+    if (h && h->log_callback)
+        h->log_callback(h->log_context, msg, n);
+}
+
+void Lovok_log_puts(LOVOK_HANDLE h, const char *msg) {
+    if (msg)
+        Lovok_log(h, msg, strlen(msg));
+}
+
+void Lovok_log_printf(LOVOK_HANDLE h, const char *fmt, ...) {
+    va_list ap;
+
+    va_start(ap, fmt);
+    Lovok_log_vprintf(h, fmt, ap);
+    va_end(ap);
+}
+
+void Lovok_log_vprintf(LOVOK_HANDLE h, const char *fmt, va_list ap) {
+    char buf[128];
+
+    vsnprintf(buf, sizeof(buf), fmt, ap);
+    Lovok_log_puts(h, buf);
+}

--- a/src/lovok_handle_internal.h
+++ b/src/lovok_handle_internal.h
@@ -8,6 +8,9 @@
 
 typedef struct LovokHandleInternal {
     FileWrapper *wrapper;
+
+    void (*log_callback)(void *ctx, const char *msg, size_t n);
+    void *log_context;
 } *LOVOK_HANDLE_INTERNAL;
 
 LovokStatusCode ParseBoxes(FileWrapper *, uint64_t, uint64_t, const std::function<LovokStatusCode(const Box &, uint64_t)> &);


### PR DESCRIPTION
As discussed on a call just before Thanksgiving, this is more or less how I'd expect logging to work in a C library meant to be adapted to multiple platforms.

We store a log callback in the Lovok handle, then add a few wrapper functions to call printf on it.   Putting the callback in the Lovok handle helps us to avoid global variables.  Looking at the library, I think a refactor might be necessary to pass the Lovok handle deeper in the call stack (opened #90 for this)

Feel free to take this or leave it or provide review feedback.